### PR TITLE
Plane: Add Q_TAILSIT_BTABRT

### DIFF
--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -165,13 +165,13 @@ const AP_Param::GroupInfo Tailsitter::var_info[] = {
     // @Range: 0 15
     AP_GROUPINFO("MIN_VO", 22, Tailsitter, disk_loading_min_outflow, 0),
 
-    // @Param: BACKTRANS_BAILOUT_TIME
-    // @DisplayName: Back transition bailout time
+    // @Param: BTABRT
+    // @DisplayName: Back transition abort time
     // @Description: Time in milliseconds to wait before considering back transition from fixed wing to VTOL flight aborted
     // @Range: 500 30000
     // @Units: ms
     // @User: Advanced
-    AP_GROUPINFO("BACKTRANS_BAILOUT_TIME", 23, Tailsitter, backtrans_bailout_time, 7000),
+    AP_GROUPINFO("BTABRT", 23, Tailsitter, backtrans_abort_time, 7000),
 
     AP_GROUPEND
 };
@@ -867,12 +867,11 @@ void Tailsitter_Transition::update()
 
     case TRANSITION_ANGLE_WAIT_VTOL:
         // Add a time check if we're stuck in TRANSITION_ANGLE_WAIT_VTOL due to a failed back transition
-        if (now - vtol_transition_start_ms > tailsitter.backtrans_bailout_time) {
-            // We are stuck in this state, so we need to bail out and go back to transition done
+        if (now - vtol_transition_start_ms > tailsitter.backtrans_abort_time) {
+            // We are stuck in this state, so we need to abort and go back to transition done
             // This is a safety measure to prevent the vehicle from getting stuck in this state indefinitely which can cause unsafe behaviour
-            // Send a message to the GCS indicating that we are bailing out of this state
-            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Bailing out of TRANSITION_ANGLE_WAIT_VTOL! Using timeout: %f", tailsitter.backtrans_bailout_time/1000);
-            GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Backtrans bailout done!");
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Exiting stuck backtransition state, timeout (s): %f", tailsitter.backtrans_abort_time/1000);
+            GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Backtrans abort done!");
             transition_state = TRANSITION_DONE;
         }
         break;

--- a/ArduPlane/tailsitter.h
+++ b/ArduPlane/tailsitter.h
@@ -110,6 +110,7 @@ public:
     AP_Float VTOL_pitch_scale;
     AP_Float VTOL_yaw_scale;
     AP_Float disk_loading_min_outflow;
+    AP_Float backtrans_bailout_time;
 
     AP_MotorsTailsitter* tailsitter_motors;
 

--- a/ArduPlane/tailsitter.h
+++ b/ArduPlane/tailsitter.h
@@ -110,7 +110,7 @@ public:
     AP_Float VTOL_pitch_scale;
     AP_Float VTOL_yaw_scale;
     AP_Float disk_loading_min_outflow;
-    AP_Float backtrans_bailout_time;
+    AP_Float backtrans_abort_time;
 
     AP_MotorsTailsitter* tailsitter_motors;
 


### PR DESCRIPTION
Issue description RCA: https://www.notion.so/Ardupilot-Tailsitter-Back-Transition-Failure-Investigation-1be21adf4be980958802c0b403208185

Parameter added: Q_TAILSIT_BTABRT for stuck back transition abort timeout in the case when we bail out of a back transition by switching to FBWA/other Fixed wing modes before a back transition to VTOL is done. 

SITL testing done with commit https://github.com/AirboundInc/ardupilot/pull/1/commits/4d75436c221fc3469ac0f0b59c09c5dfa9f1f7d7

![Screenshot 2025-04-15 160714](https://github.com/user-attachments/assets/98915bc9-6967-4880-a30f-eb95e47bd73c)

SITL Build link: https://drive.google.com/file/d/1rbSvhLzD7gekuh4o4n8YVJdAy5FaIOaU/view?usp=drive_link
Pix6cbdshot build link: https://drive.google.com/file/d/1OAdgBJ2vcn8AIk9P4kUZpPyCKGqChbVY/view?usp=drive_link


