### PR TITLE
[AIRB-76] Plane: Handle tailsitter back transition abort with force transition complete

### DIFF
--- a/.github/workflows/cygwin_build.yml
+++ b/.github/workflows/cygwin_build.yml
@@ -215,7 +215,7 @@ jobs:
           fail: true
 
       - name: Archive build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: binaries
           path: artifacts

--- a/.github/workflows/esp32_build.yml
+++ b/.github/workflows/esp32_build.yml
@@ -256,7 +256,7 @@ jobs:
           ls bootloader* partition* Ardu*.elf Ardu*.bin >> $GITHUB_STEP_SUMMARY
 
       - name: Archive artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
            name: esp32-binaries -${{matrix.config}}
            path: |

--- a/.github/workflows/test_dds.yml
+++ b/.github/workflows/test_dds.yml
@@ -180,7 +180,7 @@ jobs:
           Tools/scripts/build_ci.sh
 
       - name: Archive buildlog artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
            name: fail-${{matrix.config}}

--- a/.github/workflows/test_replay.yml
+++ b/.github/workflows/test_replay.yml
@@ -193,7 +193,7 @@ jobs:
           Tools/scripts/build_ci.sh
 
       - name: Archive buildlog artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
            name: fail-${{ matrix.toolchain }}-${{matrix.config}}

--- a/.github/workflows/test_sitl_blimp.yml
+++ b/.github/workflows/test_sitl_blimp.yml
@@ -248,7 +248,7 @@ jobs:
           Tools/scripts/build_ci.sh
 
       - name: Archive buildlog artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
            name: fail-${{matrix.config}}
@@ -262,7 +262,7 @@ jobs:
            retention-days: 14
 
       - name: Archive .bin artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
            name: BIN-${{matrix.config}}
            path: /__w/ardupilot/ardupilot/logs

--- a/.github/workflows/test_sitl_copter.yml
+++ b/.github/workflows/test_sitl_copter.yml
@@ -252,7 +252,7 @@ jobs:
           Tools/scripts/build_ci.sh
 
       - name: Archive buildlog artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
            name: fail-${{matrix.config}}
@@ -266,7 +266,7 @@ jobs:
            retention-days: 14
 
       - name: Archive .bin artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
            name: BIN-${{matrix.config}}
            path: /__w/ardupilot/ardupilot/logs
@@ -348,7 +348,7 @@ jobs:
           Tools/scripts/build_ci.sh
 
       - name: Archive buildlog artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
            name: fail-${{matrix.config}}
@@ -362,7 +362,7 @@ jobs:
            retention-days: 14
 
       - name: Archive .bin artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
            name: BIN-${{matrix.config}}
            path: /__w/ardupilot/ardupilot/logs

--- a/.github/workflows/test_sitl_plane.yml
+++ b/.github/workflows/test_sitl_plane.yml
@@ -248,7 +248,7 @@ jobs:
           Tools/scripts/build_ci.sh
 
       - name: Archive buildlog artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
            name: fail-${{matrix.config}}
@@ -262,7 +262,7 @@ jobs:
            retention-days: 14
 
       - name: Archive .bin artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
            name: BIN-${{matrix.config}}
            path: /__w/ardupilot/ardupilot/logs

--- a/.github/workflows/test_sitl_rover.yml
+++ b/.github/workflows/test_sitl_rover.yml
@@ -250,7 +250,7 @@ jobs:
           Tools/scripts/build_ci.sh
 
       - name: Archive buildlog artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
            name: fail-${{matrix.config}}
@@ -264,7 +264,7 @@ jobs:
            retention-days: 14
 
       - name: Archive .bin artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
            name: BIN-${{matrix.config}}
            path: /__w/ardupilot/ardupilot/logs

--- a/.github/workflows/test_sitl_sub.yml
+++ b/.github/workflows/test_sitl_sub.yml
@@ -249,7 +249,7 @@ jobs:
           Tools/scripts/build_ci.sh
 
       - name: Archive buildlog artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
            name: fail-${{matrix.config}}
@@ -263,7 +263,7 @@ jobs:
            retention-days: 14
 
       - name: Archive .bin artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
            name: BIN-${{matrix.config}}
            path: /__w/ardupilot/ardupilot/logs

--- a/.github/workflows/test_sitl_tracker.yml
+++ b/.github/workflows/test_sitl_tracker.yml
@@ -249,7 +249,7 @@ jobs:
           Tools/scripts/build_ci.sh
 
       - name: Archive buildlog artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
            name: fail-${{matrix.config}}
@@ -263,7 +263,7 @@ jobs:
            retention-days: 14
 
       - name: Archive .bin artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
            name: BIN-${{matrix.config}}
            path: /__w/ardupilot/ardupilot/logs

--- a/.github/workflows/test_unit_tests.yml
+++ b/.github/workflows/test_unit_tests.yml
@@ -149,7 +149,7 @@ jobs:
           Tools/scripts/build_ci.sh
 
       - name: Archive buildlog artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
            name: fail-${{ matrix.toolchain }}-${{matrix.config}}

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -121,6 +121,12 @@ void Plane::stabilize_roll()
     }
 
     const float roll_out = stabilize_roll_get_roll_out();
+    AP::logger().Write("ATTR", "TimeUS,RollOut",
+        "sd", // seconds, degrees
+        "F0", // micro (1e-6), no mult (1e0)
+        "Qf", // uint64_t, float
+        AP_HAL::micros64(),
+        roll_out/100.0f);
     SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, roll_out);
 }
 
@@ -174,6 +180,12 @@ void Plane::stabilize_pitch()
     }
 
     const float pitch_out = stabilize_pitch_get_pitch_out();
+    AP::logger().Write("ATTP", "TimeUS,PitchOut",
+        "sd", // seconds, degrees
+        "F0", // micro (1e-6), no mult (1e0)
+        "Qf", // uint64_t, float
+        AP_HAL::micros64(),
+        pitch_out/100.0f);
     SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, pitch_out);
 }
 
@@ -361,6 +373,12 @@ void Plane::stabilize_yaw()
       now calculate rudder for the rudder
      */
     const float rudder_output = calc_nav_yaw_coordinated();
+    AP::logger().Write("ATTY", "TimeUS,YawOut",
+        "sd", // seconds, degrees
+        "F0", // micro (1e-6), no mult (1e0)
+        "Qf", // uint64_t, float
+        AP_HAL::micros64(),
+        rudder_output/100.0f);
 
     if (!ground_steering) {
         // Not doing ground steering, output rudder on steering channel

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -858,7 +858,9 @@ void Tailsitter_Transition::update()
     }
 
     case TRANSITION_ANGLE_WAIT_VTOL:
-        // nothing to do, this is handled in the fixed wing attitude controller
+        // handle a rapid back transition to VTOL flight which is aborted and we're back to FW mode
+        force_transition_complete();
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Back transition abort handled!");
         break;
 
     case TRANSITION_DONE:

--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,14 +6,14 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduPlane V4.5.7"
+#define THISFIRMWARE "ArduPlane V4.5.7 - force backtrans abort"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,5,7,FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FIRMWARE_VERSION 4,5,7,FIRMWARE_VERSION_TYPE_DEV
 
 #define FW_MAJOR 4
 #define FW_MINOR 5
 #define FW_PATCH 7
-#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
+#define FW_TYPE FIRMWARE_VERSION_TYPE_DEV
 
 #include <AP_Common/AP_FWVersionDefine.h>


### PR DESCRIPTION
Instead of having a timeout, cleanly force transition to complete in case of an aborted back transition. Added a log to capture the forced transition complete.

SITL binary: https://drive.google.com/file/d/1RISWyAygoxfH1rRzZSvq4dZFOr2TF--p/view?usp=drive_link

PIX6C binary: https://drive.google.com/file/d/1IMA7Gg79gCnKUqnyPpRHPwe_c6ymDzxf/view?usp=drive_link

![Screenshot 2025-04-15 170004](https://github.com/user-attachments/assets/9171f77b-88c0-4145-b031-4b8b2d682e7d)
