### PR TITLE
AIRB-368 Weathervane at pos1 in RTL

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2684,7 +2684,11 @@ void QuadPlane::vtol_position_controller(void)
                                                   2*position2_dist_threshold + stopping_distance(rel_groundspeed_sq));
 
                 target_speed_xy_cms = diff_wp_norm * target_speed * 100;
-                have_target_yaw = true;
+                if (!tailsitter.enabled()) {
+                  // for tailsitters we want to weathervane as soon as we are in
+                  // vtol mode in position 1
+                  have_target_yaw = true;
+                }
 
                 // adjust target yaw angle for wind. We calculate yaw based on the target speed
                 // we want assuming no speed scaling due to direction

--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,7 +6,7 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduPlane V4.5.7 - force backtrans abort"
+#define THISFIRMWARE "ArduPlane V4.5.7 - weathervane pos1 rtl"
 
 // the following line is parsed by the autotest scripts
 #define FIRMWARE_VERSION 4,5,7,FIRMWARE_VERSION_TYPE_DEV

--- a/libraries/AC_PID/AC_PID.cpp
+++ b/libraries/AC_PID/AC_PID.cpp
@@ -289,6 +289,7 @@ float AC_PID::update_all(float target, float measurement, float dt, bool limit, 
     _pid_info.D = D_out;
     _pid_info.FF = _target * _kff;
     _pid_info.DFF = _target_derivative * _kdff;
+    _pid_info.output = P_out + D_out + _integrator;
 
     return P_out + D_out + _integrator;
 }

--- a/libraries/AC_PID/AP_PIDInfo.h
+++ b/libraries/AC_PID/AP_PIDInfo.h
@@ -17,6 +17,7 @@ struct AP_PIDInfo {
     float DFF;
     float Dmod;
     float slew_rate;
+    float output;
     bool limit;
     bool PD_limit;
     bool reset;

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -509,6 +509,7 @@ void AP_Logger::Write_PID(uint8_t msg_type, const AP_PIDInfo &info)
         DFF             : info.DFF,
         Dmod            : info.Dmod,
         slew_rate       : info.slew_rate,
+        output          : info.output,
         flags           : flags
     };
     WriteBlock(&pkt, sizeof(pkt));

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -408,6 +408,7 @@ struct PACKED log_PID {
     float   DFF;
     float   Dmod;
     float   slew_rate;
+    float   output;
     uint8_t flags;
 };
 
@@ -680,10 +681,10 @@ struct PACKED log_VER {
 // UNIT messages define units which can be referenced by FMTU messages
 // FMTU messages associate types (e.g. centimeters/second/second) to FMT message fields
 
-#define PID_LABELS "TimeUS,Tar,Act,Err,P,I,D,FF,DFF,Dmod,SRate,Flags"
-#define PID_FMT    "QffffffffffB"
-#define PID_UNITS  "s-----------"
-#define PID_MULTS  "F-----------"
+#define PID_LABELS "TimeUS,Tar,Act,Err,P,I,D,FF,DFF,Dmod,SRate,Out,Flags"
+#define PID_FMT    "QfffffffffffB"
+#define PID_UNITS  "s------------"
+#define PID_MULTS  "F------------"
 
 #define PIDx_FMT "Qffffffff"
 #define PIDx_UNITS "smmnnnooo"


### PR DESCRIPTION
In the default implementation for tailsitters, weathervaning only starts at position 2 during RTL
https://ardupilot.org/plane/docs/quadplane_rtl.html

This PR changes this to guarantee weathervaning starts immediately post backtransition to give better stability to the craft