### PR TITLE
Throttle boosting with respect to the TRT’s orientation and the orientation of the thrust vectors (TVs)

### DIFF
--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -318,6 +318,9 @@ void Tailsitter::output(void)
     // throttle 0 to 1
     float throttle = SRV_Channels::get_output_scaled(SRV_Channel::k_throttle) * 0.01;
 
+    // To inform the attitude controller that tailsitter is enabled
+    quadplane.attitude_control->set_tailsitter_enabled(true);
+
     // handle forward flight modes and transition to VTOL modes
     if (!active() || in_vtol_transition()) {
         // get FW controller throttle demand and mask of motors enabled during forward flight
@@ -510,6 +513,7 @@ void Tailsitter::output(void)
         }
         quadplane.weathervane->set_gain(weathervane_gain);
     }
+    quadplane.attitude_control->get_tilt_motor_angle((tilt_left + tilt_right)/2.0f);
     SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft, tilt_left);
     SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, tilt_right);
 

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.h
@@ -63,6 +63,9 @@ public:
     // calculate total body frame throttle required to produce the given earth frame throttle
     float get_throttle_boosted(float throttle_in);
 
+    // calculate total body frame throttle required to produce the given earth frame throttle for vectored thrust tailsitters
+    float get_throttle_boosted_ts(float throttle_in);
+
     // set desired throttle vs attitude mixing (actual mix is slewed towards this value over 1~2 seconds)
     //  low values favour pilot/autopilot throttle over attitude control, high values favour attitude control over throttle
     //  has no effect when throttle is above hover throttle
@@ -83,6 +86,11 @@ public:
 
     // set the PID notch sample rates
     void set_notch_sample_rate(float sample_rate) override;
+
+    // set tailsitter enabled flag
+    void set_tailsitter_enabled(bool enabled = false) { _ts_enabled = enabled; }
+    
+    void get_tilt_motor_angle(float tilt_angle){_ts_tilt_angle = tilt_angle;}
 
     // user settable parameters
     static const struct AP_Param::GroupInfo var_info[];
@@ -149,4 +157,7 @@ protected:
 
     // angle_p/pd boost multiplier
     AP_Float              _throttle_gain_boost;
+
+    bool                _ts_enabled = false;  // tailsitter enabled flag
+    float               _ts_tilt_angle = 0.0f; // tailsitter tilt motor angle
 };


### PR DESCRIPTION
Notion page https://www.notion.so/airbound/Decoupling-the-vertical-and-Attitude-controllers-2c321adf4be980b89fa5cae73ac286fb?source=copy_link. 
Refer only angle boosting