### PR TITLE
Rotary Encoder Driver for Thrust Vectors

### DIFF
--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -448,16 +448,6 @@ const struct LogStructure Plane::log_structure[] = {
       "TSIT", "Qfff",  "TimeUS,Ts,Ss,Tmin", "s---", "F---" , true },
 #endif
 
-// @LoggerMessage: RENC
-// @Description: Rotary Encoder values for the tailsitter thrust vectors
-// @Field: TimeUS: time of the log
-// @Field: PosL: angle on the left thrust vector
-// @Field: PosR: angle on the right thrust vector
-#if HAL_QUADPLANE_ENABLED
-    { LOG_ROTARYENCODER_MSG, sizeof(log_RotaryEncoder),
-      "RENC", "Qff", "TimeUS,PosL,PosR", "sdd", "F--", true },
-#endif
-
 // @LoggerMessage: PIDG
 // @Description: Plane Proportional/Integral/Derivative gain values for Heading when using COMMAND_INT control.
 // @Field: TimeUS: Time since system startup

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -448,6 +448,16 @@ const struct LogStructure Plane::log_structure[] = {
       "TSIT", "Qfff",  "TimeUS,Ts,Ss,Tmin", "s---", "F---" , true },
 #endif
 
+// @LoggerMessage: RENC
+// @Description: Rotary Encoder values for the tailsitter thrust vectors
+// @Field: TimeUS: time of the log
+// @Field: PosL: angle on the left thrust vector
+// @Field: PosR: angle on the right thrust vector
+#if HAL_QUADPLANE_ENABLED
+    { LOG_ROTARYENCODER_MSG, sizeof(log_RotaryEncoder),
+      "RENC", "Qff", "TimeUS,PosL,PosR", "sdd", "F--", true },
+#endif
+
 // @LoggerMessage: PIDG
 // @Description: Plane Proportional/Integral/Derivative gain values for Heading when using COMMAND_INT control.
 // @Field: TimeUS: Time since system startup

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -547,6 +547,12 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     // @User: Advanced
     AP_GROUPINFO("LND_FRZ_TIM", 39, QuadPlane, q_land_freeze_time, 7.0f),
 
+#if HAL_QUADPLANE_ENABLED
+    // @Group: RE_
+    // @Path: ../libraries/AP_RotaryEncoder/AP_RotaryEncoder.cpp
+    AP_SUBGROUPINFO(rotary_encoder, "RE_", 40, QuadPlane, AP_RotaryEncoder), 
+#endif
+
     AP_GROUPEND
 };
 
@@ -848,6 +854,8 @@ bool QuadPlane::setup(void)
     pilot_accel_z.convert_centi_parameter(AP_PARAM_INT16);
 
     tailsitter.setup();
+
+    rotary_encoder.init();
 
     tiltrotor.setup();
 

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -21,6 +21,7 @@
 #include <AP_Logger/LogStructure.h>
 #include <AP_Mission/AP_Mission.h>
 #include <AP_Proximity/AP_Proximity.h>
+#include <AP_RotaryEncoder/AP_RotaryEncoder.h>
 #include "qautotune.h"
 #include "defines.h"
 #include "tailsitter.h"
@@ -584,6 +585,9 @@ private:
 
     // time when motors were last active
     uint32_t last_motors_active_ms;
+
+    // rotary encoder input for thrust vectoring
+    AP_RotaryEncoder rotary_encoder;
 
     // time when we last ran the vertical accel controller
     uint32_t last_pidz_active_ms;

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -190,6 +190,61 @@ const AP_Param::GroupInfo Tailsitter::var_info[] = {
     // @Range: 45 60
     AP_GROUPINFO("WV_MI", 26, Tailsitter, wvane_pitch_mid, 45),
 
+    // @Param: E1A
+    // @DisplayName: Encoder 1 Pin A
+    // @Description: GPIO pin number for encoder 1 channel A input
+    // @Range: -1 255
+    // @Values: -1:Disabled,50:AUX1,51:AUX2,52:AUX3,53:AUX4,54:AUX5,55:AUX6
+    // @User: Standard
+    AP_GROUPINFO("E1A", 27, Tailsitter, encoder1_pin_a, -1),
+
+    // @Param: E1B
+    // @DisplayName: Encoder 1 Pin B
+    // @Description: GPIO pin number for encoder 1 channel B input
+    // @Range: -1 255
+    // @Values: -1:Disabled,50:AUX1,51:AUX2,52:AUX3,53:AUX4,54:AUX5,55:AUX6
+    // @User: Standard
+    AP_GROUPINFO("E1B", 28, Tailsitter, encoder1_pin_b, -1),
+
+    // @Param: E1CPR
+    // @DisplayName: Encoder 1 Counts Per Revolution
+    // @Description: Number of encoder counts per full 360 degree revolution for encoder 1
+    // @Range: 1 10000
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("E1CPR", 29, Tailsitter, encoder1_cpr, 4096),
+
+    // @Param: E2A
+    // @DisplayName: Encoder 2 Pin A
+    // @Description: GPIO pin number for encoder 2 channel A input
+    // @Range: -1 255
+    // @Values: -1:Disabled,50:AUX1,51:AUX2,52:AUX3,53:AUX4,54:AUX5,55:AUX6
+    // @User: Standard
+    AP_GROUPINFO("E2A", 30, Tailsitter, encoder2_pin_a, -1),
+    
+    // @Param: E2B
+    // @DisplayName: Encoder 2 Pin B
+    // @Description: GPIO pin number for encoder 2 channel B input
+    // @Range: -1 255
+    // @Values: -1:Disabled,50:AUX1,51:AUX2,52:AUX3,53:AUX4,54:AUX5,55:AUX6
+    // @User: Standard
+    AP_GROUPINFO("E2B", 31, Tailsitter, encoder2_pin_b, -1),
+
+    // @Param: E2CPR
+    // @DisplayName: Encoder 2 Counts Per Revolution
+    // @Description: Number of encoder counts per full 360 degree revolution for encoder 2
+    // @Range: 1 10000
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("E2CPR", 32, Tailsitter, encoder2_cpr, 4096),
+
+
+    // @Param: RE_DB
+    // @DisplayName: Tailsitter enable rotary encoder realtime gcs statements
+    // @Description: Make this true to get rotary encoder angles displayed on the GCS logs for both the left and right encoders on the thrust vector.
+    // @Range: 0 1
+    AP_GROUPINFO("RE_DB", 33, Tailsitter, log_gcs_rotary_encoder, 0),
+
     AP_GROUPEND
 };
 
@@ -272,6 +327,8 @@ void Tailsitter::setup()
     }
     quadplane.transition = transition;
 
+    rotary_encoder_zero = true;
+
     setup_complete = true;
 }
 
@@ -310,6 +367,24 @@ void Tailsitter::output(void)
     if (!enabled() || quadplane.motor_test.running || !quadplane.initialised) {
         // if motor test is running we don't want to overwrite it with output_motor_mask or motors_output
         return;
+    }
+    if(rotary_encoder_zero && (AP_HAL::millis() > quadplane.rotary_encoder.get_init_time_ms())) {
+        quadplane.rotary_encoder.set_position_offset(0, quadplane.rotary_encoder.get_angular_position(0,true));
+        quadplane.rotary_encoder.set_position_offset(1, quadplane.rotary_encoder.get_angular_position(1,true));
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "initial offset L:%f R:%f", quadplane.rotary_encoder.get_angular_position(0, true), quadplane.rotary_encoder.get_angular_position(1, true));
+        rotary_encoder_zero = false;
+    }
+
+    // Call rotary_encoder update to refresh encoder values
+    quadplane.rotary_encoder.update();
+
+    // Log on GCS in realtime if demanded by the user
+    if(log_gcs_rotary_encoder) {
+        static uint32_t last_time = 0;
+        if (AP_HAL::millis() - last_time > 1000) {
+            last_time = AP_HAL::millis();
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Thrust Angles L:%f R:%f", quadplane.rotary_encoder.get_angular_position(0, true), quadplane.rotary_encoder.get_angular_position(1, true));
+        }
     }
 
     float tilt_left = 0.0f;
@@ -871,6 +946,8 @@ void Tailsitter::write_log()
         min_throttle        : log_data.min_throttle,
     };
     plane.logger.WriteBlock(&pkt, sizeof(pkt));
+
+    quadplane.rotary_encoder.Log_Write();
 }
 #endif  // HAL_LOGGING_ENABLED
 

--- a/ArduPlane/tailsitter.h
+++ b/ArduPlane/tailsitter.h
@@ -17,6 +17,7 @@
 #include <AP_Param/AP_Param.h>
 #include "transition.h"
 #include <AP_Motors/AP_MotorsTailsitter.h>
+#include <AP_RotaryEncoder/AP_RotaryEncoder.h>
 #include <AP_Logger/LogStructure.h>
 
 class QuadPlane;
@@ -110,11 +111,22 @@ public:
     AP_Float VTOL_pitch_scale;
     AP_Float VTOL_yaw_scale;
     AP_Float disk_loading_min_outflow;
+    AP_Int8 log_gcs_rotary_encoder;
 
     AP_Float wvane_max_gain;
     AP_Float wvane_pitch_low;
     AP_Float wvane_pitch_hi;
     AP_Float wvane_pitch_mid;
+
+    // Encoder parameters
+    AP_Int16 encoder1_pin_a;
+    AP_Int16 encoder1_pin_b;
+    AP_Int16 encoder1_cpr;
+    AP_Int16 encoder2_pin_a;
+    AP_Int16 encoder2_pin_b;
+    AP_Int16 encoder2_cpr;
+
+    AP_RotaryEncoder rotary_encoder;
 
     AP_MotorsTailsitter* tailsitter_motors;
 
@@ -138,6 +150,7 @@ private:
 
 
     bool setup_complete;
+    bool rotary_encoder_zero;
 
     // true when flying a tilt-vectored tailsitter
     bool _is_vectored;

--- a/ArduPlane/wscript
+++ b/ArduPlane/wscript
@@ -31,6 +31,7 @@ def build(bld):
             'AP_Follow',
             'AC_PrecLand',
             'AP_IRLock',
+            'AP_RotaryEncoder',
         ],
     )
 

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -116,6 +116,7 @@ COMMON_VEHICLE_DEPENDENT_LIBRARIES = [
     'AP_OpenDroneID',
     'AP_CheckFirmware',
     'AP_ExternalControl',
+    'AP_RotaryEncoder',
 ]
 
 def get_legacy_defines(sketch_name, bld):

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -420,6 +420,13 @@ struct PACKED log_WheelEncoder {
     uint8_t quality_1;
 };
 
+struct PACKED log_RotaryEncoder {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    float pos_left;
+    float pos_right;
+};
+
 struct PACKED log_ADSB {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -1406,6 +1413,7 @@ enum LogMessages : uint8_t {
     LOG_OPTFLOW_MSG,
     LOG_EVENT_MSG,
     LOG_WHEELENCODER_MSG,
+    LOG_ROTARYENCODER_MSG,
     LOG_MAV_MSG,
     LOG_ERROR_MSG,
     LOG_ADSB_MSG,

--- a/libraries/AP_RotaryEncoder/AP_Quadrature.cpp
+++ b/libraries/AP_RotaryEncoder/AP_Quadrature.cpp
@@ -1,0 +1,109 @@
+#include <AP_HAL/AP_HAL.h>
+
+#include "AP_Quadrature.h"
+
+#include <GCS_MAVLink/GCS.h>
+
+extern const AP_HAL::HAL& hal;
+
+const int8_t AP_Quadrature::_lookupTable[16] = {
+    0,  -1,   1,   0,
+    1,   0,   0,  -1,
+   -1,   0,   0,   1,
+    0,   1,  -1,   0
+};
+
+// Constructor
+AP_Quadrature::AP_Quadrature(AP_RotaryEncoder &frontend, uint8_t instance, AP_RotaryEncoder::RotaryEncoder_State &state) :
+    AP_RotaryEncoder_Backend(frontend, instance, state)
+{
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AP_Quadrature backend created for instance %d", instance);
+}
+
+void AP_Quadrature::update_pin(uint8_t &pin, uint8_t new_pin, uint8_t &pin_value)
+{
+
+    if (new_pin == pin) {
+        // no change
+        return;
+    }
+
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "QEnc update_pin: instance %d, old_pin %d, new_pin %d", _state.instance, pin, new_pin);
+
+    // remove old gpio event callback if present
+    if (pin != UINT8_MAX &&
+        !hal.gpio->detach_interrupt(pin)) {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "QEnc: Failed to detach from pin %u", pin);
+        // ignore this failure or the user may be stuck
+    }
+
+    pin = new_pin;
+
+    // install interrupt handler on rising or falling edge of gpio for pin a
+    if (new_pin != UINT8_MAX) {
+        hal.gpio->pinMode(pin, HAL_GPIO_INPUT);
+        if (!hal.gpio->attach_interrupt(
+                pin,
+                FUNCTOR_BIND_MEMBER(&AP_Quadrature::irq_handler, void, uint8_t, bool, uint32_t), AP_HAL::GPIO::INTERRUPT_BOTH)) {
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "QEnc: Failed to attach to pin %u", pin);
+        }
+        pin_value = hal.gpio->read(pin);
+    }
+}
+
+void AP_Quadrature::irq_handler(uint8_t pin, bool pin_value, uint32_t timestamp)
+{
+    // Add interrupt debug
+    static uint32_t irq_count = 0;
+    irq_count++;
+    
+
+    uint8_t index = 0;
+    if(pin == _pinA) {
+        index = A_value << 3 | B_value << 2 | pin_value << 1 | B_value;
+        A_value = pin_value;
+    }
+    else if(pin == _pinB) {
+        index = A_value << 3 | B_value << 2 | A_value << 1 | pin_value;
+        B_value = pin_value;
+    }
+    else {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "IRQ on unknown pin %d (instance %d)", pin, _state.instance);
+        return;
+    }
+
+    int8_t direction = _lookupTable[index];
+
+    // Accumulate phase changes first
+    irq_state.phase += direction;
+    
+    // Calculate velocity using a sliding window approach
+    uint32_t current_time_us = timestamp;
+    
+    // Get CPR from frontend and calculate angle
+    uint16_t cpr = _frontend.get_counts_per_revolution(_state.instance);
+    if (cpr > 0) {
+        irq_state.angle = irq_state.phase * (360.0f / cpr);
+    } else {
+        irq_state.angle = 0.0f;
+    }
+
+    irq_state.time = current_time_us;
+}
+
+void AP_Quadrature::update(void)
+{
+    update_pin(_pinA, get_pin_a(), A_value);
+    update_pin(_pinB, get_pin_b(), B_value);
+
+    // disable interrupts to prevent race with irq_handler
+    void *irqstate = hal.scheduler->disable_interrupts_save();
+
+    // copy count, angle, and last timestamp so it is accessible to front end
+    copy_state_to_frontend(irq_state.phase,
+                           irq_state.angle,
+                           irq_state.time);
+
+    // restore interrupts
+    hal.scheduler->restore_interrupts(irqstate);
+}

--- a/libraries/AP_RotaryEncoder/AP_Quadrature.h
+++ b/libraries/AP_RotaryEncoder/AP_Quadrature.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <AP_RotaryEncoder/AP_RotaryEncoder.h>
+#include <AP_RotaryEncoder/AP_RotaryEncoder_Backend.h>
+#include <Filter/Filter.h>
+#include <AP_Math/AP_Math.h>
+
+class AP_Quadrature : public AP_RotaryEncoder_Backend
+{   public:
+    // constructor
+    AP_Quadrature(AP_RotaryEncoder &frontend, uint8_t instance, AP_RotaryEncoder::RotaryEncoder_State &state);
+
+    // update state
+    void update(void) override;
+
+private:
+    
+    // check if pin has changed and initialise gpio event callback
+    void update_pin(uint8_t &pin, uint8_t new_pin, uint8_t &pin_value);
+
+    // gpio interrupt handlers
+    void irq_handler(uint8_t pin, bool pin_value, uint32_t timestamp); // combined irq handler
+
+    // convert pin a and b status to phase
+    static uint8_t pin_ab_to_phase(bool pin_a, bool pin_b);
+
+    // update phase, rotation_count and error count using pin a and b's latest state
+    void update_phase_and_error_count();
+
+    struct IrqState {
+        int32_t     phase;             
+        uint32_t    angle;             
+        uint32_t    time;
+    } irq_state;
+
+    uint8_t _pinA = -1;
+    uint8_t _pinB = -1;
+    uint8_t A_value, B_value;
+    
+    static const int8_t _lookupTable[16];
+
+    uint32_t last_status_report = 0;  // per-instance timer
+
+};

--- a/libraries/AP_RotaryEncoder/AP_RotaryEncoder.cpp
+++ b/libraries/AP_RotaryEncoder/AP_RotaryEncoder.cpp
@@ -1,0 +1,256 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "AP_RotaryEncoder.h"
+#include "AP_Quadrature.h"
+#include <AP_Logger/AP_Logger.h>
+#include <GCS_MAVLink/GCS.h>
+
+extern const AP_HAL::HAL& hal;
+
+// table of user settable parameters
+const struct AP_Param::GroupInfo AP_RotaryEncoder::var_info[] = {
+    // @Param: LT
+    // @DisplayName: RotaryEncoder type for left encoder
+    // @Description: What type of RotaryEncoder is connected
+    // @Values: 0:None,1:Quadrature
+    // @User: Standard
+    // @RebootRequired: True
+    AP_GROUPINFO_FLAGS("LT", 0, AP_RotaryEncoder, _type[0], 0, AP_PARAM_FLAG_ENABLE),
+
+    // @Param: LC
+    // @DisplayName: RotaryEncoder counts per revolution for left encoder
+    // @Description: RotaryEncoder counts per full revolution of the rotary encoder
+    // @Increment: 1
+    // @User: Standard
+    // @RebootRequired: True
+    AP_GROUPINFO("LC",     1, AP_RotaryEncoder, _counts_per_revolution[0], ROTARY_ENCODER_CPR_DEFAULT),
+
+    // @Param: LA
+    // @DisplayName: Input Pin A for left encoder
+    // @Description: Input Pin A
+    // @Values: -1:Disabled,50:AUX1,51:AUX2,52:AUX3,53:AUX4,54:AUX5,55:AUX6
+    // @User: Standard
+    // @RebootRequired: True
+    AP_GROUPINFO("LA",   2, AP_RotaryEncoder, _pina[0], -1),
+
+    // @Param: LB
+    // @DisplayName: Input Pin B for left encoder
+    // @Description: Input Pin B
+    // @Values: -1:Disabled,50:AUX1,51:AUX2,52:AUX3,53:AUX4,54:AUX5,55:AUX6
+    // @User: Standard
+    // @RebootRequired: True
+    AP_GROUPINFO("LB",   3, AP_RotaryEncoder, _pinb[0], -1),
+
+#if ROTARY_ENCODER_MAX_INSTANCES > 1
+    // @Param: RT
+    // @DisplayName: RotaryEncoder type for right encoder
+    // @Description: What type of RotaryEncoder sensor is connected
+    // @Values: 0:None,1:Quadrature
+    // @User: Standard
+    // @RebootRequired: True
+    AP_GROUPINFO("RT",   4, AP_RotaryEncoder, _type[1], 0),
+
+    // @Param: RC
+    // @DisplayName: RotaryEncoder counts per revolution for right encoder
+    // @Description: RotaryEncoder counts per full revolution of the rotary encoder
+    // @Increment: 1
+    // @User: Standard
+    // @RebootRequired: True
+    AP_GROUPINFO("RC",   5, AP_RotaryEncoder, _counts_per_revolution[1], ROTARY_ENCODER_CPR_DEFAULT),
+
+    // @Param: RA
+    // @DisplayName: Input Pin A for right encoder 
+    // @Description: Input Pin A
+    // @Values: -1:Disabled,50:AUX1,51:AUX2,52:AUX3,53:AUX4,54:AUX5,55:AUX6
+    // @User: Standard
+    // @RebootRequired: True
+    AP_GROUPINFO("RA",   6, AP_RotaryEncoder, _pina[1], -1),
+
+    // @Param: RB
+    // @DisplayName: Input Pin B for right encoder
+    // @Description: Input Pin B
+    // @Values: -1:Disabled,50:AUX1,51:AUX2,52:AUX3,53:AUX4,54:AUX5,55:AUX6
+    // @User: Standard
+    // @RebootRequired: True
+    AP_GROUPINFO("RB",   7, AP_RotaryEncoder, _pinb[1], -1),
+#endif
+
+    // @Param: TIME
+    // @DisplayName: time before setting the zero position
+    // @Description: Time in milliseconds after arming to wait before setting the zero position of the rotary encoder
+    // @Units: ms
+    // @Range: 0 60000
+    // @User: Standard
+    AP_GROUPINFO("TIME", 8, AP_RotaryEncoder, init_time_ms, 5000),
+
+    AP_GROUPEND
+};
+
+AP_RotaryEncoder::AP_RotaryEncoder(void)
+{
+    _singleton = this;
+
+    AP_Param::setup_object_defaults(this, var_info);
+}
+
+// initialise the AP_RotaryEncoder class.
+void AP_RotaryEncoder::init(void)
+{
+    if (num_instances != 0) {
+        // init called a 2nd time?
+        return;
+    }
+    
+    for (uint8_t i=0; i<ROTARY_ENCODER_MAX_INSTANCES; i++) {
+        
+        switch ((RotaryEncoder_Type)_type[i].get()) {
+
+        case RotaryEncoder_TYPE_QUADRATURE:
+            drivers[i] = new AP_Quadrature(*this, i, state[i]);
+            break;
+        case RotaryEncoder_TYPE_NONE:
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "No encoder configured for instance %d", i);
+            break;
+        }
+
+        if (drivers[i] != nullptr) {
+            // we loaded a driver for this instance, so it must be
+            // present (although it may not be healthy)
+            num_instances = i+1;  // num_instances is a high-water-mark
+        }
+    }
+}
+
+// update RotaryEncoder state for all instances. This should be called by main loop
+void AP_RotaryEncoder::update(void)
+{
+    // Early return if no encoders are configured to save CPU cycles
+    if (!any_enabled()) {
+        return;
+    }
+    
+    for (uint8_t i=0; i<num_instances; i++) {
+        if (drivers[i] != nullptr && _type[i] != RotaryEncoder_TYPE_NONE) {
+            drivers[i]->update();
+        }
+    }
+}
+
+#if HAL_LOGGING_ENABLED
+// log rotary encoder information
+void AP_RotaryEncoder::Log_Write() const
+{
+    // return immediately if no rotary encoders are enabled
+    if (!enabled(0) && !enabled(1)) {
+        return;
+    }
+
+    struct log_RotaryEncoder pkt = {
+        LOG_PACKET_HEADER_INIT(LOG_ROTARYENCODER_MSG),
+        time_us     : AP_HAL::micros64(),
+        pos_left    : get_angular_position(0, true),
+        pos_right   : get_angular_position(1, true),
+    };
+    AP::logger().WriteBlock(&pkt, sizeof(pkt));
+}
+#endif
+
+// check if an instance is healthy
+bool AP_RotaryEncoder::healthy(uint8_t instance) const
+{
+    if (instance >= num_instances) {
+        return false;
+    }
+    return true;
+}
+
+// check if an instance is activated
+bool AP_RotaryEncoder::enabled(uint8_t instance) const
+{
+    if (instance >= num_instances) {
+        return false;
+    }
+    // if no sensor type is selected, the sensor is not activated.
+    if (_type[instance] == RotaryEncoder_TYPE_NONE) {
+        return false;
+    }
+    return true;
+}
+
+// check if any encoder instance is configured and enabled
+bool AP_RotaryEncoder::any_enabled(void) const
+{
+    for (uint8_t i = 0; i < ROTARY_ENCODER_MAX_INSTANCES; i++) {
+        if (_type[i] != RotaryEncoder_TYPE_NONE && 
+            _pina[i] != -1 && 
+            _pinb[i] != -1) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// get the counts per revolution of the encoder
+uint16_t AP_RotaryEncoder::get_counts_per_revolution(uint8_t instance) const
+{
+    // for invalid instances return zero vector
+    if (instance >= ROTARY_ENCODER_MAX_INSTANCES) {
+        return 0;
+    }
+    return (uint16_t)_counts_per_revolution[instance];
+}
+
+// get the angular position in degrees
+float AP_RotaryEncoder::get_angular_position(uint8_t instance, bool degrees) const
+{
+    // for invalid instances return zero
+    if (instance >= ROTARY_ENCODER_MAX_INSTANCES) {
+        return 0.0f;
+    }
+
+    float position = M_2_PI * state[instance].count / _counts_per_revolution[instance];
+    return degrees ? position * (180.0f / M_PI) - pos_offset_zero[instance] : position - pos_offset_zero[instance] * M_2_PI / _counts_per_revolution[instance];
+}
+
+// get the system time (in milliseconds) of the last update
+uint32_t AP_RotaryEncoder::get_last_reading_ms(uint8_t instance) const
+{
+    // for invalid instances return zero
+    if (instance >= ROTARY_ENCODER_MAX_INSTANCES) {
+        return 0;
+    }
+    return state[instance].time;
+}
+
+void AP_RotaryEncoder::set_position_offset(uint8_t instance, float position) {
+    pos_offset_zero[instance] = position;
+}
+
+uint32_t AP_RotaryEncoder::get_init_time_ms() const {
+    return init_time_ms.get();
+}
+
+// singleton instance
+AP_RotaryEncoder *AP_RotaryEncoder::_singleton;
+
+namespace AP {
+
+AP_RotaryEncoder *rotaryencoder()
+{
+    return AP_RotaryEncoder::get_singleton();
+}
+
+}

--- a/libraries/AP_RotaryEncoder/AP_RotaryEncoder.h
+++ b/libraries/AP_RotaryEncoder/AP_RotaryEncoder.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <AP_Common/AP_Common.h>
+#include <AP_Param/AP_Param.h>
+#include <AP_Math/AP_Math.h>
+
+// Maximum number of RotaryEncoder measurement instances available on this platform
+#define ROTARY_ENCODER_MAX_INSTANCES      2
+#define ROTARY_ENCODER_CPR_DEFAULT        4096    // default encoder counts per full revolution of the rotary encoder
+
+
+class AP_RotaryEncoder_Backend; 
+ 
+class AP_RotaryEncoder
+{
+public:
+    friend class AP_RotaryEncoder_Backend;
+    friend class AP_RotaryEncoder_Quadrature;
+
+    AP_RotaryEncoder(void);
+
+    /* Do not allow copies */
+    CLASS_NO_COPY(AP_RotaryEncoder );
+
+    // get singleton instance
+    static AP_RotaryEncoder *get_singleton() {
+        return _singleton;
+    }
+
+    // RotaryEncoder driver types
+    enum RotaryEncoder_Type : uint8_t {
+        RotaryEncoder_TYPE_NONE             =   0,
+        RotaryEncoder_TYPE_QUADRATURE       =   1,
+    };
+
+    // The RotaryEncoder_State structure is filled in by the backend driver
+    struct RotaryEncoder_State {
+        uint8_t                instance;                        // the instance number of this RotaryEncoder
+        int32_t                count;                           // encoder position in counts 0 to CPR
+        float                  angular_position;                // total angle measured in radians
+        uint32_t               time;                           // time change (in milliseconds) for the previous period (used to calculating rate)
+    };
+
+    // detect and initialise any available rpm sensors
+    void init(void);
+
+    // update state of all sensors. Should be called from main loop
+    void update(void);
+
+    // log data to logger
+    void Log_Write() const;
+
+    // return the number of rotary encoder sensor instances
+    uint8_t num_sensors(void) const { return num_instances; }
+
+    // return true if healthy
+    bool healthy(uint8_t instance) const;
+
+    // return true if the instance is enabled
+    bool enabled(uint8_t instance) const;
+
+    // return true if any encoder instance is configured and enabled
+    bool any_enabled(void) const;
+
+    // get the counts per revolution of the encoder
+    uint16_t get_counts_per_revolution(uint8_t instance) const;
+
+    // get total delta angle (in radians) measured by the rotary encoder
+    float get_delta_angle(uint8_t instance) const;
+
+    // get the total angle position (in radians) measured by the rotary encoder
+    float get_angular_position(uint8_t instance, bool degrees) const;
+
+    // get the system time (in milliseconds) of the last update
+    uint32_t get_last_reading_ms(uint8_t instance) const;
+
+    // set zero value in rotary encoder
+    void set_position_offset(uint8_t instance, float position);
+
+    // get time in milliseconds after arming to wait before setting the zero position of the rotary encoder
+    uint32_t get_init_time_ms() const; 
+
+    static const struct AP_Param::GroupInfo var_info[];
+
+protected:
+    // parameters for each instance
+    AP_Int8  _type[ROTARY_ENCODER_MAX_INSTANCES];
+    AP_Int16 _counts_per_revolution[ROTARY_ENCODER_MAX_INSTANCES];
+    AP_Int8  _pina[ROTARY_ENCODER_MAX_INSTANCES];
+    AP_Int8  _pinb[ROTARY_ENCODER_MAX_INSTANCES];
+    AP_Int32 init_time_ms;
+    float pos_offset_zero[ROTARY_ENCODER_MAX_INSTANCES];
+
+    RotaryEncoder_State state[ROTARY_ENCODER_MAX_INSTANCES];
+    AP_RotaryEncoder_Backend *drivers[ROTARY_ENCODER_MAX_INSTANCES];
+    uint8_t num_instances;
+
+private:
+
+    static AP_RotaryEncoder *_singleton;
+};
+
+namespace AP {
+    AP_RotaryEncoder *rotaryencoder();
+}

--- a/libraries/AP_RotaryEncoder/AP_RotaryEncoder_Backend.cpp
+++ b/libraries/AP_RotaryEncoder/AP_RotaryEncoder_Backend.cpp
@@ -1,0 +1,55 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <AP_Common/AP_Common.h>
+#include "AP_RotaryEncoder.h"
+#include "AP_RotaryEncoder_Backend.h"
+
+// base class constructor.
+AP_RotaryEncoder_Backend::AP_RotaryEncoder_Backend(AP_RotaryEncoder &frontend, uint8_t instance, AP_RotaryEncoder::RotaryEncoder_State &state) :
+        _frontend(frontend),
+        _state(state) 
+{
+    state.instance = instance;
+}
+
+// return pin.  returns -1 if pin is not defined for this instance
+int8_t AP_RotaryEncoder_Backend::get_pin_a() const
+{
+    if (_state.instance >= ROTARY_ENCODER_MAX_INSTANCES) {
+        return -1;
+    }
+    return _frontend._pina[_state.instance].get();
+}
+
+// return pin.  returns -1 if pin is not defined for this instance
+int8_t AP_RotaryEncoder_Backend::get_pin_b() const
+{
+    if (_state.instance >= ROTARY_ENCODER_MAX_INSTANCES) {
+        return -1;
+    }
+    return _frontend._pinb[_state.instance].get();
+}
+
+// copy state to front end helper function
+void AP_RotaryEncoder_Backend::copy_state_to_frontend(int32_t count, uint32_t angular_position, uint32_t time)
+{
+    // record rotation and time change for calculating rate before previous state is overwritten
+    _state.time = time;
+
+    // copy rotation and error count so it is accessible to front end
+    _state.count = count;
+    _state.angular_position = angular_position;
+}

--- a/libraries/AP_RotaryEncoder/AP_RotaryEncoder_Backend.h
+++ b/libraries/AP_RotaryEncoder/AP_RotaryEncoder_Backend.h
@@ -1,0 +1,44 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#pragma once
+
+#include <AP_Common/AP_Common.h>
+#include "AP_RotaryEncoder.h"
+
+class AP_RotaryEncoder_Backend
+{
+public:
+    // constructor. This incorporates initialisation as well.
+    AP_RotaryEncoder_Backend(AP_RotaryEncoder &frontend, uint8_t instance, AP_RotaryEncoder::RotaryEncoder_State &state);
+
+    // we declare a virtual destructor so that RotaryEncoder drivers can
+    // override with a custom destructor if need be
+    virtual ~AP_RotaryEncoder_Backend(void) {}
+
+    // update the state structure. All backends must implement this.
+    virtual void update() = 0;
+
+protected:
+
+    // return pin number.  returns -1 if pin is not defined for this instance
+    int8_t get_pin_a() const;
+    int8_t get_pin_b() const;
+
+    // copy state to front end helper function
+    void copy_state_to_frontend(int32_t count, uint32_t angle, uint32_t time);
+
+    AP_RotaryEncoder &_frontend;
+    AP_RotaryEncoder::RotaryEncoder_State &_state;
+};


### PR DESCRIPTION
Add rotary encoder with quadrature architecture to measure angles

ISR based system called from HAL
Define in ArduPlane, with other sensors and servos
Add parameters to assign the appropriate pins and variables for the rotary encoder
Add synchronous modules that update a global instance at a fixed time
Add data flash logs as "RENC"

https://www.notion.so/airbound/Phi-Rotary-Encoders-on-Pixhawk-26f21adf4be9803e8c71ef67b8d1c1ee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added rotary encoder support for tailsitter thrust vectoring, enabling configuration of two independent encoders with adjustable pins and counts-per-revolution settings. Includes telemetry logging of encoder positions and optional real-time GCS feedback for thrust vector angles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->