### PR TITLE
airbound 4.5.7: Update autobailout and autoparadeploy parameters to ensure effective bailout and paradeploy behaviour

### DIFF
--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,7 +6,7 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "Airbound ArduPlane V4.5.7.4 -hf1"
+#define THISFIRMWARE "Airbound ArduPlane V4.5.7.4 -hf1 + autob parm chg"
 
 // the following line is parsed by the autotest scripts
 #define FIRMWARE_VERSION 4,5,7,FIRMWARE_VERSION_TYPE_DEV

--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
@@ -10,10 +10,10 @@ assert(param:add_table(KEY, "AUTOB_", 7), "AUTOB table failed")
 assert(param:add_param(KEY, 1,  "PIT_LIM", 40),'could not add AUTOB_PIT_LIM')    -- Pitch limit
 assert(param:add_param(KEY, 2, "ENABLE", 1),'could not add AUTOB_ENABLE')    -- 1 = Enabled
 assert(param:add_param(KEY, 3, "MODE_DLY", 1000), 'could not add AUTOB_MODE_DLY') -- Delay (ms) before checking pitch
-assert(param:add_param(KEY, 4,"PIT_TOUT", 500),'could not add AUTOB_PIT_TOUT')
+assert(param:add_param(KEY, 4,"PIT_TOUT", 200),'could not add AUTOB_PIT_TOUT')
 assert(param:add_param(KEY, 5, "PARA_EN", 1),'could not add AUTOB_PARA_EN')    -- 1 = Enabled
-assert(param:add_param(KEY, 6,"PARA_ANG", -45),'could not add AUTOB_PARA_ANG')
-assert(param:add_param(KEY, 7,"PARA_TOUT", 200),'could not add AUTOB_PARA_TOUT')
+assert(param:add_param(KEY, 6,"PARA_ANG", -15),'could not add AUTOB_PARA_ANG')
+assert(param:add_param(KEY, 7,"PARA_TOUT", 100),'could not add AUTOB_PARA_TOUT')
 
 -- 3. BIND PARAMETERS
 local function bind_param(name)

--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
@@ -1,6 +1,8 @@
 -- Tailsitter Recovery Loop Script
 -- Logic: Bad Pitch -> Save Mode -> QLoiter
 local LOOP_MS = 100 -- Run at 10Hz
+local para_ahrs_pitch_threshold_max = -10
+local para_ahrs_pitch_threshold_min = -50
 
 -- 1. SETUP PARAMETER TABLE
 local KEY = 110
@@ -66,9 +68,7 @@ end
 
 function is_parachute_angle_threshold_valid(threshold_angle)
 -- check if the threshold angle set by user is valid
-    ahrs_pitch_threshold_max = -10
-    ahrs_pitch_threshold_min = -50
-    if threshold_angle < ahrs_pitch_threshold_max and threshold_angle > ahrs_pitch_threshold_min then
+    if threshold_angle < para_ahrs_pitch_threshold_max and threshold_angle > para_ahrs_pitch_threshold_min then
         return true
     end
     return false
@@ -93,7 +93,7 @@ function para_deploy()
     
     para_threshold = p_para_ang:get() or -45
     if not is_parachute_angle_threshold_valid(para_threshold) then
-        gcs:send_text(2, "AUTOB:AUTB_PARA_ANG invalid. Range(-50,-10)")    
+        gcs:send_text(2, string.format("AUTOB:AUTB_PARA_ANG invalid. Range(%.1f, %.1f)",para_ahrs_pitch_threshold_min, para_ahrs_pitch_threshold_max))    
         return
     end
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
@@ -66,7 +66,7 @@ end
 
 function is_parachute_angle_threshold_valid(threshold_angle)
 -- check if the threshold angle set by user is valid
-    ahrs_pitch_threshold_max = -40
+    ahrs_pitch_threshold_max = -10
     ahrs_pitch_threshold_min = -50
     if threshold_angle < ahrs_pitch_threshold_max and threshold_angle > ahrs_pitch_threshold_min then
         return true
@@ -93,7 +93,7 @@ function para_deploy()
     
     para_threshold = p_para_ang:get() or -45
     if not is_parachute_angle_threshold_valid(para_threshold) then
-        gcs:send_text(2, "AUTOB:AUTB_PARA_ANG invalid. Range(-40,-50)")    
+        gcs:send_text(2, "AUTOB:AUTB_PARA_ANG invalid. Range(-50,-10)")    
         return
     end
 


### PR DESCRIPTION
Changes the following parameters 
AUTOB_PIT_TOUT = 500 -> 200
AUTOB_PARA_ANG = -45 -> -15
AUTOB_PARA_TOUT = 200 -> 100

Notion Page: https://www.notion.so/airbound/Update-Autobailout-and-Autoparadeploy-flight-parameters-based-on-historical-log-analysis-36821adf4be980e5b2fbcc865ca51610?source=copy_link