### PR TITLE
Pr auto heading change takeoff

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -547,6 +547,15 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     // @User: Advanced
     AP_GROUPINFO("LND_FRZ_TIM", 39, QuadPlane, q_land_freeze_time, 7.0f),
 
+    // @Param: TKOFF_YAW_TOL
+    // @DisplayName: Takeoff yaw tolerance
+    // @Description: Yaw error tolerance in degrees before fixed-wing transition after VTOL takeoff
+    // @Units: deg
+    // @Range: 5 60
+    // @User: Standard
+    AP_GROUPINFO("YAW_TOL", 41, QuadPlane, takeoff_yaw_tol, 20),
+
+
     AP_GROUPEND
 };
 
@@ -3592,7 +3601,7 @@ if (plane.current_loc.alt < plane.next_WP_loc.alt) {
 
     if (takeoff_wp_bearing_cd >= 0.0f) {
         float yaw_error_cd = fabsf(wrap_180_cd((float)ahrs.yaw_sensor - takeoff_wp_bearing_cd - 18000.0f));
-        if (yaw_error_cd > 1000.0f) {  // more than 10 degrees off
+        if (yaw_error_cd > takeoff_yaw_tol * 100.0f) {
             static uint32_t last_print_ms = 0;
             if (now - last_print_ms >= 1000) {
                 last_print_ms = now;

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3291,7 +3291,7 @@ void QuadPlane::takeoff_controller(void)
 
     // takeoff yaw handling added on 02-June-2026 *Stefard*
     set_pilot_yaw_rate_time_constant();
-    if (takeoff_alt_hold_start_ms != 0 && (AP_HAL::millis() - takeoff_alt_hold_start_ms) < 10000) {
+    if (takeoff_alt_hold_start_ms != 0) {
         // hold altitude during pause phase
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(plane.nav_roll_cd,
                                                                       plane.nav_pitch_cd,
@@ -3489,6 +3489,7 @@ bool QuadPlane::do_vtol_takeoff(const AP_Mission::Mission_Command& cmd)
 
     // takeoff yaw handling added on 02-June-2026 *Stefard*
     takeoff_alt_hold_start_ms = 0;
+    takeoff_wp_bearing_cd = -1.0f;
     // End of Change *Stefard*
 
     return true;
@@ -3568,20 +3569,31 @@ if (plane.current_loc.alt < plane.next_WP_loc.alt) {
     }
 
 // takeoff yaw handling added on 02-June-2026 *Stefard*
-// 10-second hold at takeoff altitude before fixed-wing transition
-if (takeoff_alt_hold_start_ms == 0) {
+    // Hold altitude until heading aligns with next waypoint, then transition
+    if (takeoff_alt_hold_start_ms == 0) {
         takeoff_alt_hold_start_ms = now;
-    }
-const uint32_t hold_elapsed_ms = now - takeoff_alt_hold_start_ms;
-if (hold_elapsed_ms < 10000) {
-        uint8_t secs_remaining = (uint8_t)((10000 - hold_elapsed_ms + 999) / 1000);
-                static uint8_t last_sec = 255;
-        if (secs_remaining != last_sec) {
-            last_sec = secs_remaining;
-            gcs().send_text(MAV_SEVERITY_INFO, "Takeoff hold: %u sec remaining", (unsigned)secs_remaining);
+        takeoff_start_time_ms = now;  // reset failure timeout for hold phase
+        AP_Mission::Mission_Command next_cmd;
+        if (plane.mission.get_next_nav_cmd(plane.mission.get_current_nav_index() + 1, next_cmd)) {
+            takeoff_wp_bearing_cd = (float)plane.current_loc.get_bearing_to(next_cmd.content.location);
+            gcs().send_text(MAV_SEVERITY_INFO, "Takeoff: holding, target heading %.0f deg",
+                            (double)(takeoff_wp_bearing_cd * 0.01f));
         }
+        // if no next waypoint, takeoff_wp_bearing_cd stays -1 and we transition immediately
+    }
 
-        return false;
+    if (takeoff_wp_bearing_cd >= 0.0f) {
+        float yaw_error_cd = fabsf(wrap_180_cd((float)ahrs.yaw_sensor - takeoff_wp_bearing_cd));
+        if (yaw_error_cd > 1000.0f) {  // more than 10 degrees off
+            static uint32_t last_print_ms = 0;
+            if (now - last_print_ms >= 1000) {
+                last_print_ms = now;
+                gcs().send_text(MAV_SEVERITY_INFO, "Takeoff: waiting for heading, error %.0f deg",
+                                (double)(yaw_error_cd * 0.01f));
+            }
+            return false;
+        }
+        gcs().send_text(MAV_SEVERITY_INFO, "Takeoff: heading aligned, transitioning");
     }
 // End of Change *Stefard*
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3591,11 +3591,14 @@ if (plane.current_loc.alt < plane.next_WP_loc.alt) {
         takeoff_alt_hold_start_ms = now;
         takeoff_start_time_ms = now;  // reset failure timeout for hold phase
         AP_Mission::Mission_Command next_cmd;
-        if (plane.mission.get_next_nav_cmd(plane.mission.get_current_nav_index() + 1, next_cmd)) {
+        if (plane.mission.get_next_nav_cmd(plane.mission.get_current_nav_index() + 1, next_cmd)
+            && next_cmd.content.location.lat != 0
+            && next_cmd.content.location.lng != 0) {
             takeoff_wp_bearing_cd = (float)plane.current_loc.get_bearing_to(next_cmd.content.location);
             gcs().send_text(MAV_SEVERITY_INFO, "Takeoff: holding, target heading %.0f deg",
                             (double)(takeoff_wp_bearing_cd * 0.01f));
         }
+
         // if no next waypoint, takeoff_wp_bearing_cd stays -1 and we transition immediately
     }
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3290,25 +3290,34 @@ void QuadPlane::takeoff_controller(void)
     // End of commented out block *Stefard*
 
     // takeoff yaw handling added on 02-June-2026 *Stefard*
-    if (takeoff_yaw_active) {
-    // Yaw phase: hold position, zero climb, command absolute yaw
-    disable_yaw_rate_time_constant();
-    attitude_control->input_euler_angle_roll_pitch_yaw(plane.nav_roll_cd,
-                                                       plane.nav_pitch_cd,
-                                                       takeoff_yaw_target_cd, true);
-    set_climb_rate_cms(0);
-} else {
     set_pilot_yaw_rate_time_constant();
-    attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(plane.nav_roll_cd,
-                                                                  plane.nav_pitch_cd,
-                                                                  get_pilot_input_yaw_rate_cds() + get_weathervane_yaw_rate_cds());
+    if (takeoff_alt_hold_start_ms != 0 && (AP_HAL::millis() - takeoff_alt_hold_start_ms) < 10000) {
+        // hold altitude during pause phase
+        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(plane.nav_roll_cd,
+                                                                      plane.nav_pitch_cd,
+                                                                      get_pilot_input_yaw_rate_cds());
+        set_climb_rate_cms(0);
+    } else {
+        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(plane.nav_roll_cd,
+                                                                      plane.nav_pitch_cd,
+                                                                      get_pilot_input_yaw_rate_cds() + get_weathervane_yaw_rate_cds());
+        float vel_z = wp_nav->get_default_speed_up();
+        if (plane.control_mode == &plane.mode_guided && guided_takeoff) {
+            Location origin;
+            if (ahrs.get_origin(origin)) {
+                const int32_t margin_cm = 5;
+                float pos_z = margin_cm + plane.next_WP_loc.alt - origin.alt;
+                vel_z = 0;
+                pos_control->input_pos_vel_accel_z(pos_z, vel_z, 0);
+            } else {
+                set_climb_rate_cms(vel_z);
+            }
+        } else {
+            set_climb_rate_cms(vel_z);
+        }
+    }
+    run_z_controller();
 
-    float vel_z = wp_nav->get_default_speed_up();
-    // ... keep existing guided_takeoff branch exactly as-is
-    set_climb_rate_cms(vel_z);
-}
-
-run_z_controller();
 // End of Change *Stefard*
 }
 
@@ -3479,8 +3488,7 @@ bool QuadPlane::do_vtol_takeoff(const AP_Mission::Mission_Command& cmd)
     takeoff_time_limit_ms = MAX(travel_time * takeoff_failure_scalar * 1000, 5000); // minimum time 5 seconds
 
     // takeoff yaw handling added on 02-June-2026 *Stefard*
-    takeoff_yaw_active = false;
-    takeoff_yaw_target_cd = 0.0f;
+    takeoff_alt_hold_start_ms = 0;
     // End of Change *Stefard*
 
     return true;
@@ -3560,31 +3568,21 @@ if (plane.current_loc.alt < plane.next_WP_loc.alt) {
     }
 
 // takeoff yaw handling added on 02-June-2026 *Stefard*
-// Tailsitter-only: yaw to face next waypoint before transitioning
-if (tailsitter.enabled()) {
-    if (!takeoff_yaw_active) {
-        // First time altitude reached — compute bearing to next nav waypoint
-        AP_Mission::Mission_Command next_cmd;
-        if (plane.mission.get_next_nav_cmd(plane.mission.get_current_nav_index() + 1, next_cmd)) {
-            takeoff_yaw_target_cd = (float)plane.current_loc.get_bearing_to(next_cmd.content.location);
-            takeoff_yaw_active = true;
-            takeoff_start_time_ms = now;  // reset timeout for the yaw phase
-            gcs().send_text(MAV_SEVERITY_INFO, "Takeoff: yawing to %.0f deg", (double)(takeoff_yaw_target_cd * 0.01f));
-            return false;
-        }
-        // No next waypoint — fall through and transition immediately
+// 10-second hold at takeoff altitude before fixed-wing transition
+if (takeoff_alt_hold_start_ms == 0) {
+        takeoff_alt_hold_start_ms = now;
     }
+const uint32_t hold_elapsed_ms = now - takeoff_alt_hold_start_ms;
+if (hold_elapsed_ms < 10000) {
+        uint8_t secs_remaining = (uint8_t)((10000 - hold_elapsed_ms + 999) / 1000);
+                static uint8_t last_sec = 255;
+        if (secs_remaining != last_sec) {
+            last_sec = secs_remaining;
+            gcs().send_text(MAV_SEVERITY_INFO, "Takeoff hold: %u sec remaining", (unsigned)secs_remaining);
+        }
 
-    if (takeoff_yaw_active) {
-        float yaw_error_cd = fabsf(wrap_180_cd((float)ahrs.yaw_sensor - takeoff_yaw_target_cd));
-        if (yaw_error_cd > 1000.0f) {   // > 10 degrees, keep waiting
-            return false;
-        }
-        // Aligned — clear flag and proceed to transition
-        takeoff_yaw_active = false;
-        gcs().send_text(MAV_SEVERITY_INFO, "Takeoff: aligned, transitioning");
+        return false;
     }
-}
 // End of Change *Stefard*
 
 transition->restart();

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3600,7 +3600,7 @@ if (plane.current_loc.alt < plane.next_WP_loc.alt) {
     }
 
     if (takeoff_wp_bearing_cd >= 0.0f) {
-        float yaw_error_cd = fabsf(wrap_180_cd((float)ahrs.yaw_sensor - takeoff_wp_bearing_cd - 18000.0f));
+        float yaw_error_cd = fabsf(wrap_180_cd((float)ahrs_view->yaw_sensor - takeoff_wp_bearing_cd));
         if (yaw_error_cd > takeoff_yaw_tol * 100.0f) {
             static uint32_t last_print_ms = 0;
             if (now - last_print_ms >= 1000) {

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3261,32 +3261,54 @@ void QuadPlane::takeoff_controller(void)
     }
 
     run_xy_controller();
+    // commented out below on 02-June-2026 *Stefard* 
+    //set_pilot_yaw_rate_time_constant();
+    //attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(plane.nav_roll_cd,
+                                                                  plane.nav_pitch_cd,
+                                                                  get_pilot_input_yaw_rate_cds() + get_weathervane_yaw_rate_cds());
 
+    //float vel_z = wp_nav->get_default_speed_up();
+    // if (plane.control_mode == &plane.mode_guided && guided_takeoff) {
+        // for guided takeoff we aim for a specific height with zero
+        // velocity at that height
+    //    Location origin;
+    //    if (ahrs.get_origin(origin)) {
+            // a small margin to ensure we do move to the next takeoff
+            // stage
+    //        const int32_t margin_cm = 5;
+    //        float pos_z = margin_cm + plane.next_WP_loc.alt - origin.alt;
+    //        vel_z = 0;
+    //        pos_control->input_pos_vel_accel_z(pos_z, vel_z, 0);
+    //    } else {
+    //        set_climb_rate_cms(vel_z);
+    //    }
+    //} else {
+    //    set_climb_rate_cms(vel_z);
+    //}
+    //run_z_controller();
+    // End of commented out block *Stefard*
+
+    // takeoff yaw handling added on 02-June-2026 *Stefard*
+    if (takeoff_yaw_active) {
+    // Yaw phase: hold position, zero climb, command absolute yaw
+    disable_yaw_rate_time_constant();
+    attitude_control->input_euler_angle_roll_pitch_yaw(plane.nav_roll_cd,
+                                                       plane.nav_pitch_cd,
+                                                       takeoff_yaw_target_cd, true);
+    set_climb_rate_cms(0);
+} else {
     set_pilot_yaw_rate_time_constant();
     attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(plane.nav_roll_cd,
                                                                   plane.nav_pitch_cd,
                                                                   get_pilot_input_yaw_rate_cds() + get_weathervane_yaw_rate_cds());
 
     float vel_z = wp_nav->get_default_speed_up();
-    if (plane.control_mode == &plane.mode_guided && guided_takeoff) {
-        // for guided takeoff we aim for a specific height with zero
-        // velocity at that height
-        Location origin;
-        if (ahrs.get_origin(origin)) {
-            // a small margin to ensure we do move to the next takeoff
-            // stage
-            const int32_t margin_cm = 5;
-            float pos_z = margin_cm + plane.next_WP_loc.alt - origin.alt;
-            vel_z = 0;
-            pos_control->input_pos_vel_accel_z(pos_z, vel_z, 0);
-        } else {
-            set_climb_rate_cms(vel_z);
-        }
-    } else {
-        set_climb_rate_cms(vel_z);
-    }
+    // ... keep existing guided_takeoff branch exactly as-is
+    set_climb_rate_cms(vel_z);
+}
 
-    run_z_controller();
+run_z_controller();
+// End of Change *Stefard*
 }
 
 /*
@@ -3451,8 +3473,14 @@ bool QuadPlane::do_vtol_takeoff(const AP_Mission::Mission_Command& cmd)
     const float travel_time = MAX(t_accel, 0) + MAX(t_constant, 0);
 
     // setup the takeoff failure handling code
+    
     takeoff_start_time_ms = millis();
     takeoff_time_limit_ms = MAX(travel_time * takeoff_failure_scalar * 1000, 5000); // minimum time 5 seconds
+
+    // takeoff yaw handling added on 02-June-2026 *Stefard*
+    takeoff_yaw_active = false;
+    takeoff_yaw_target_cd = 0.0f;
+    // End of Change *Stefard*
 
     return true;
 }
@@ -3526,10 +3554,40 @@ bool QuadPlane::verify_vtol_takeoff(const AP_Mission::Mission_Command &cmd)
     }
 #endif
 
-    if (plane.current_loc.alt < plane.next_WP_loc.alt) {
-        return false;
+if (plane.current_loc.alt < plane.next_WP_loc.alt) {
+    return false;
+}
+
+// takeoff yaw handling added on 02-June-2026 *Stefard*
+// Tailsitter-only: yaw to face next waypoint before transitioning
+if (tailsitter.enabled()) {
+    if (!takeoff_yaw_active) {
+        // First time altitude reached — compute bearing to next nav waypoint
+        AP_Mission::Mission_Command next_cmd;
+        if (plane.mission.get_next_nav_cmd(plane.mission.get_current_nav_index() + 1, next_cmd)) {
+            takeoff_yaw_target_cd = (float)plane.current_loc.get_bearing_to(next_cmd.content.location);
+            takeoff_yaw_active = true;
+            takeoff_start_time_ms = now;  // reset timeout for the yaw phase
+            gcs().send_text(MAV_SEVERITY_INFO, "Takeoff: yawing to %.0f deg", (double)(takeoff_yaw_target_cd * 0.01f));
+            return false;
+        }
+        // No next waypoint — fall through and transition immediately
     }
-    transition->restart();
+
+    if (takeoff_yaw_active) {
+        float yaw_error_cd = fabsf(wrap_180_cd((float)ahrs.yaw_sensor - takeoff_yaw_target_cd));
+        if (yaw_error_cd > 1000.0f) {   // > 10 degrees, keep waiting
+            return false;
+        }
+        // Aligned — clear flag and proceed to transition
+        takeoff_yaw_active = false;
+        gcs().send_text(MAV_SEVERITY_INFO, "Takeoff: aligned, transitioning");
+    }
+}
+// End of Change *Stefard*
+
+transition->restart();
+
     plane.TECS_controller.set_pitch_max_limit(transition_pitch_max);
 
     // todo: why are you doing this, I want to delete it.

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3583,7 +3583,7 @@ if (plane.current_loc.alt < plane.next_WP_loc.alt) {
         takeoff_start_time_ms = now;  // reset failure timeout for hold phase
         AP_Mission::Mission_Command next_cmd;
         if (plane.mission.get_next_nav_cmd(plane.mission.get_current_nav_index() + 1, next_cmd)) {
-            takeoff_wp_bearing_cd = (float)plane.current_loc.get_bearing_to(next_cmd.content.location);
+            takeoff_wp_bearing_cd = wrap_360_cd((float)plane.current_loc.get_bearing_to(next_cmd.content.location) + 18000.0f);
             gcs().send_text(MAV_SEVERITY_INFO, "Takeoff: holding, target heading %.0f deg",
                             (double)(takeoff_wp_bearing_cd * 0.01f));
         }

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3583,7 +3583,7 @@ if (plane.current_loc.alt < plane.next_WP_loc.alt) {
         takeoff_start_time_ms = now;  // reset failure timeout for hold phase
         AP_Mission::Mission_Command next_cmd;
         if (plane.mission.get_next_nav_cmd(plane.mission.get_current_nav_index() + 1, next_cmd)) {
-            takeoff_wp_bearing_cd = wrap_360_cd((float)plane.current_loc.get_bearing_to(next_cmd.content.location) + 18000.0f);
+            takeoff_wp_bearing_cd = (float)plane.current_loc.get_bearing_to(next_cmd.content.location);
             gcs().send_text(MAV_SEVERITY_INFO, "Takeoff: holding, target heading %.0f deg",
                             (double)(takeoff_wp_bearing_cd * 0.01f));
         }
@@ -3591,7 +3591,7 @@ if (plane.current_loc.alt < plane.next_WP_loc.alt) {
     }
 
     if (takeoff_wp_bearing_cd >= 0.0f) {
-        float yaw_error_cd = fabsf(wrap_180_cd((float)ahrs.yaw_sensor - takeoff_wp_bearing_cd));
+        float yaw_error_cd = fabsf(wrap_180_cd((float)ahrs.yaw_sensor - takeoff_wp_bearing_cd - 18000.0f));
         if (yaw_error_cd > 1000.0f) {  // more than 10 degrees off
             static uint32_t last_print_ms = 0;
             if (now - last_print_ms >= 1000) {

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3290,13 +3290,21 @@ void QuadPlane::takeoff_controller(void)
     // End of commented out block *Stefard*
 
     // takeoff yaw handling added on 02-June-2026 *Stefard*
-    set_pilot_yaw_rate_time_constant();
     if (takeoff_alt_hold_start_ms != 0) {
-        // hold altitude during pause phase
-        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(plane.nav_roll_cd,
-                                                                      plane.nav_pitch_cd,
-                                                                      get_pilot_input_yaw_rate_cds());
+        // hold altitude and actively yaw to face next waypoint
         set_climb_rate_cms(0);
+        if (takeoff_wp_bearing_cd >= 0.0f) {
+            disable_yaw_rate_time_constant();
+            attitude_control->input_euler_angle_roll_pitch_yaw(plane.nav_roll_cd,
+                                                               plane.nav_pitch_cd,
+                                                               takeoff_wp_bearing_cd, true);
+        } else {
+            set_pilot_yaw_rate_time_constant();
+            attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(plane.nav_roll_cd,
+                                                                          plane.nav_pitch_cd,
+                                                                          get_pilot_input_yaw_rate_cds());
+        }
+  
     } else {
         attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(plane.nav_roll_cd,
                                                                       plane.nav_pitch_cd,

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3261,11 +3261,12 @@ void QuadPlane::takeoff_controller(void)
     }
 
     run_xy_controller();
+
     // commented out below on 02-June-2026 *Stefard* 
     //set_pilot_yaw_rate_time_constant();
     //attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(plane.nav_roll_cd,
-                                                                  plane.nav_pitch_cd,
-                                                                  get_pilot_input_yaw_rate_cds() + get_weathervane_yaw_rate_cds());
+    //                                                              plane.nav_pitch_cd,
+    //                                                              get_pilot_input_yaw_rate_cds() + get_weathervane_yaw_rate_cds());
 
     //float vel_z = wp_nav->get_default_speed_up();
     // if (plane.control_mode == &plane.mode_guided && guided_takeoff) {
@@ -3556,7 +3557,7 @@ bool QuadPlane::verify_vtol_takeoff(const AP_Mission::Mission_Command &cmd)
 
 if (plane.current_loc.alt < plane.next_WP_loc.alt) {
     return false;
-}
+    }
 
 // takeoff yaw handling added on 02-June-2026 *Stefard*
 // Tailsitter-only: yaw to face next waypoint before transitioning

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -646,6 +646,8 @@ private:
 
     // takeoff yaw handling added on 02-June-2026 *Stefard*
     uint32_t takeoff_alt_hold_start_ms;   // nonzero once takeoff altitude is reached
+    float takeoff_wp_bearing_cd;          // bearing to next WP in centidegrees, -1 if unknown
+
     // End of Change *Stefard*
 
     // oneshot with duration ARMING_DELAY_MS used by quadplane to delay spoolup after arming:

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -644,6 +644,11 @@ private:
     uint32_t takeoff_last_run_ms;
     float takeoff_start_alt;
 
+    // takeoff yaw handling added on 02-June-2026 *Stefard*
+    bool takeoff_yaw_active;      // true while hovering and yawing to face next WP
+    float takeoff_yaw_target_cd;  // bearing to next WP in centidegrees
+    // End of Change *Stefard*
+
     // oneshot with duration ARMING_DELAY_MS used by quadplane to delay spoolup after arming:
     // ignored unless OPTION_DELAY_ARMING or OPTION_TILT_DISARMED is set
     bool delay_arming;

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -647,7 +647,7 @@ private:
     // takeoff yaw handling added on 02-June-2026 *Stefard*
     uint32_t takeoff_alt_hold_start_ms;   // nonzero once takeoff altitude is reached
     float takeoff_wp_bearing_cd;          // bearing to next WP in centidegrees, -1 if unknown
-
+    AP_Float takeoff_yaw_tol;
     // End of Change *Stefard*
 
     // oneshot with duration ARMING_DELAY_MS used by quadplane to delay spoolup after arming:

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -645,8 +645,7 @@ private:
     float takeoff_start_alt;
 
     // takeoff yaw handling added on 02-June-2026 *Stefard*
-    bool takeoff_yaw_active;      // true while hovering and yawing to face next WP
-    float takeoff_yaw_target_cd;  // bearing to next WP in centidegrees
+    uint32_t takeoff_alt_hold_start_ms;   // nonzero once takeoff altitude is reached
     // End of Change *Stefard*
 
     // oneshot with duration ARMING_DELAY_MS used by quadplane to delay spoolup after arming:

--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,7 +6,7 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "Airbound ArduPlane V4.5.7.4 - hf3_AH_v3"
+#define THISFIRMWARE "Airbound ArduPlane V4.5.7.4 - hf3_AH_v4"
 
 // the following line is parsed by the autotest scripts
 #define FIRMWARE_VERSION 4,5,7,FIRMWARE_VERSION_TYPE_DEV

--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,7 +6,7 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "Airbound ArduPlane V4.5.7.4 - hf3_AH_v1"
+#define THISFIRMWARE "Airbound ArduPlane V4.5.7.4 - hf3_AH_v2"
 
 // the following line is parsed by the autotest scripts
 #define FIRMWARE_VERSION 4,5,7,FIRMWARE_VERSION_TYPE_DEV

--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,7 +6,7 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "Airbound ArduPlane V4.5.7.4 - hf3_auto_heading_v1"
+#define THISFIRMWARE "Airbound ArduPlane V4.5.7.4 - hf3_AH_v1"
 
 // the following line is parsed by the autotest scripts
 #define FIRMWARE_VERSION 4,5,7,FIRMWARE_VERSION_TYPE_DEV

--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,7 +6,7 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "Airbound ArduPlane V4.5.7.4 - hf3_AH_v6"
+#define THISFIRMWARE "Airbound ArduPlane V4.5.7.4 - hf3_AH_v7"
 
 // the following line is parsed by the autotest scripts
 #define FIRMWARE_VERSION 4,5,7,FIRMWARE_VERSION_TYPE_DEV

--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,7 +6,7 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "Airbound ArduPlane V4.5.7.4 - hf3_AH_v2"
+#define THISFIRMWARE "Airbound ArduPlane V4.5.7.4 - hf3_AH_v3"
 
 // the following line is parsed by the autotest scripts
 #define FIRMWARE_VERSION 4,5,7,FIRMWARE_VERSION_TYPE_DEV

--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,7 +6,7 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "Airbound ArduPlane V4.5.7.4 - hf3"
+#define THISFIRMWARE "Airbound ArduPlane V4.5.7.4 - hf3_auto_heading_v1"
 
 // the following line is parsed by the autotest scripts
 #define FIRMWARE_VERSION 4,5,7,FIRMWARE_VERSION_TYPE_DEV

--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,7 +6,7 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "Airbound ArduPlane V4.5.7.4 - hf3_AH_v7"
+#define THISFIRMWARE "Airbound ArduPlane V4.5.7.4 - hf3_AH_v8"
 
 // the following line is parsed by the autotest scripts
 #define FIRMWARE_VERSION 4,5,7,FIRMWARE_VERSION_TYPE_DEV

--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,7 +6,7 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "Airbound ArduPlane V4.5.7.4 - hf3_AH_v5"
+#define THISFIRMWARE "Airbound ArduPlane V4.5.7.4 - hf3_AH_v6"
 
 // the following line is parsed by the autotest scripts
 #define FIRMWARE_VERSION 4,5,7,FIRMWARE_VERSION_TYPE_DEV

--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,7 +6,7 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "Airbound ArduPlane V4.5.7.4 - hf3_AH_v4"
+#define THISFIRMWARE "Airbound ArduPlane V4.5.7.4 - hf3_AH_v5"
 
 // the following line is parsed by the autotest scripts
 #define FIRMWARE_VERSION 4,5,7,FIRMWARE_VERSION_TYPE_DEV


### PR DESCRIPTION
This Code change makes the UAV reach takeoff altitude and then aligns the heading of the UAV towards the direction of the 2nd waypoint, on if the 2nd waypoint has co-ordinates in it. the alignment has a buffer angle that is controlled by Q_YAW_TOL (quadplane yaw tolerance), such that when the heading error of the UAV reaches within +/- Q_YAW_TOL, the UAV decides the do the FW transition.

Q_YAW_TOL has been introduced because SITL tests at 20kmph prevented the UAV from reaching the yaw error of 10 degrees which was hardcoded.

This feature only works for takeoff / VTOL takeoff waypoints, and not for FW transitions mid flight.
incase the 2nd waypoint has Lat and long = 0, the UAV does a fixed wing transition without adjusting its heading
Q_YAW_TOL needs to be tuned for our UAV in different wind conditions

https://app.notion.com/p/airbound/Yaw-Auto-Align-37521adf4be980cf8938f601adc1fd51