### PR TITLE
autobailout.lua: AUTRC_PIT_TOUT 200 -> 100

### DIFF
--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,7 +6,7 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "Airbound ArduPlane V4.5.7.4 - hf3"
+#define THISFIRMWARE "Airbound V4.5.7.4 - hf4-fast-autob"
 
 // the following line is parsed by the autotest scripts
 #define FIRMWARE_VERSION 4,5,7,FIRMWARE_VERSION_TYPE_DEV

--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
@@ -12,7 +12,7 @@ assert(param:add_table(KEY, "AUTOB_", 7), "AUTOB table failed")
 assert(param:add_param(KEY, 1,  "PIT_LIM", 40),'could not add AUTOB_PIT_LIM')    -- Pitch limit
 assert(param:add_param(KEY, 2, "ENABLE", 1),'could not add AUTOB_ENABLE')    -- 1 = Enabled
 assert(param:add_param(KEY, 3, "MODE_DLY", 1000), 'could not add AUTOB_MODE_DLY') -- Delay (ms) before checking pitch
-assert(param:add_param(KEY, 4,"PIT_TOUT", 200),'could not add AUTOB_PIT_TOUT')
+assert(param:add_param(KEY, 4,"PIT_TOUT", 100),'could not add AUTOB_PIT_TOUT')
 assert(param:add_param(KEY, 5, "PARA_EN", 1),'could not add AUTOB_PARA_EN')    -- 1 = Enabled
 assert(param:add_param(KEY, 6,"PARA_ANG", -15),'could not add AUTOB_PARA_ANG')
 assert(param:add_param(KEY, 7,"PARA_TOUT", 100),'could not add AUTOB_PARA_TOUT')


### PR DESCRIPTION
Historical log analysis done on Guntur log has led to the conclusion that a quicker autobailout will considerably help in saving the craft.  
In 4.57.4-hf3 and its variants, its observed that the Autoparadeploy triggers before Autobailout.  The pitch drops very quickly to autoparadeploy limits bypassing the autobailout check. 
Reducing AUTRC_PIT_TOUT to 100 will make the autobailout quicker to trigger

