### PR TITLE
Add resume after autobailout

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
@@ -68,6 +68,7 @@ local WINDOW_SIZE     = 50
 local pitch_error_buf = {}
 local pitch_angle_buf = {}
 local buf_idx         = 1
+local post_bailout_sample_count = 0 --used to ensure sufficient samples have been collected to decide on resuming mode
 
 local function buf_avg(buf)
     local sum, count = 0, 0
@@ -247,6 +248,7 @@ function update()
                                 first_pitch_exceeded_t = nil
                                 active = true
                                 pre_bailout_mode = current_mode
+                                post_bailout_sample_count = 0 --Reset this variable only when autobailout is active
                                 gcs:send_text(2, "AUTOB: Switching to QLoiter" )
                             end
                         end
@@ -267,9 +269,11 @@ function update()
             gcs_announce_autobailout = false
             gcs:send_text(6, "AUTOB: Manual Override Detected")
         else
+            post_bailout_sample_count = post_bailout_sample_count + 1
+            post_bailout_sample_count = math.min(post_bailout_sample_count, WINDOW_SIZE)
             local avg_lim  = p_avg_lim:get()  or 20
             local peak_lim = p_peak_lim:get() or 30
-            if avg_err < avg_lim and peak_ang < peak_lim then
+            if post_bailout_sample_count >= WINDOW_SIZE and avg_err < avg_lim and peak_ang < peak_lim then
                 if pre_bailout_mode and vehicle:set_mode(pre_bailout_mode) then
                     local recovered_mode = pre_bailout_mode
                     active = false

--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
@@ -190,13 +190,13 @@ function update()
 
     -- Detect Mode Changes
     if current_mode ~= last_mode_idx then
-            last_mode_idx = current_mode
-            first_pitch_exceeded_t = nil
-            if not active then        -- ADD THIS GUARD
-                pitch_error_buf = {}
-                pitch_angle_buf = {}
-                buf_idx = 1
-            end
+        last_mode_idx = current_mode
+        first_pitch_exceeded_t = nil
+        if not active then        -- ADD THIS GUARD
+            pitch_error_buf = {}
+            pitch_angle_buf = {}
+            buf_idx = 1
+        end
     end
 
     local win_n   = math.max(1, math.floor((p_win_s:get() or 5) * 1000 / loop_ms))

--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
@@ -1,21 +1,26 @@
 -- Tailsitter Recovery Loop Script
 -- Logic: Bad Pitch -> Save Mode -> QLoiter
-local LOOP_MS = 50 
 local para_ahrs_pitch_threshold_max = -10
 local para_ahrs_pitch_threshold_min = -50
 
 -- 1. SETUP PARAMETER TABLE
 local KEY = 110
-assert(param:add_table(KEY, "AUTOB_", 7), "AUTOB table failed")
+assert(param:add_table(KEY, "AUTOB_", 13), "AUTOB table failed")
 
 -- 2. ADD PARAMETERS
-assert(param:add_param(KEY, 1,  "PIT_LIM", 40),'could not add AUTOB_PIT_LIM')    -- Pitch limit
+assert(param:add_param(KEY, 1, "PIT_LIM",  40),  'could not add AUTOB_PIT_LIM')   -- AHRS pitch threshold to enter bailout (deg)
 assert(param:add_param(KEY, 2, "ENABLE", 1),'could not add AUTOB_ENABLE')    -- 1 = Enabled
 assert(param:add_param(KEY, 3, "BTRN_DLY", 2500), 'could not add AUTOB_BTRN_DLY') -- Delay (ms) before checking pitch
-assert(param:add_param(KEY, 4,"PIT_TOUT", 100),'could not add AUTOB_PIT_TOUT')
+assert(param:add_param(KEY, 4, "PIT_TOUT", 100), 'could not add AUTOB_PIT_TOUT')  -- Sustained duration to enter bailout (ms)
 assert(param:add_param(KEY, 5, "PARA_EN", 1),'could not add AUTOB_PARA_EN')    -- 1 = Enabled
 assert(param:add_param(KEY, 6,"PARA_ANG", -15),'could not add AUTOB_PARA_ANG')
 assert(param:add_param(KEY, 7,"PARA_TOUT", 100),'could not add AUTOB_PARA_TOUT')
+assert(param:add_param(KEY, 8,  "LOOP_MS", 50), 'could not add AUTOB_LOOP_MS')  -- Loop rate (ms)
+assert(param:add_param(KEY, 9,  "WIN_TIM",   5),   'could not add AUTOB_WIN_TIM')    -- Rolling window duration (s)
+assert(param:add_param(KEY, 10, "WIN_SMP",   50),  'could not add AUTOB_WIN_SMP')    -- Calculated samples (output, read-only)
+assert(param:add_param(KEY, 11,  "AVG_LIM", 20),'could not add AUTOB_AVG_LIM')    -- Pitch limit
+assert(param:add_param(KEY, 12,"PEAK_LIM", 30),'could not add AUTOB_PEAK_LIM')
+assert(param:add_param(KEY, 13, "DBG_EN", 0), 'could not add AUTOB_DBG_EN')  -- 1 = enable dataflash logging
 
 -- 3. BIND PARAMETERS
 local function bind_param(name)
@@ -27,12 +32,18 @@ local function bind_param(name)
 end
 
 local p_enable = bind_param("AUTOB_ENABLE")
+local p_avg_lim = bind_param("AUTOB_AVG_LIM")
+local p_peak_lim = bind_param("AUTOB_PEAK_LIM")
 local p_pit_lim = bind_param("AUTOB_PIT_LIM")
 local p_btrn_dly = bind_param("AUTOB_BTRN_DLY")
 local p_pitch_timeout = bind_param("AUTOB_PIT_TOUT")
 local p_para_enable = bind_param("AUTOB_PARA_EN")
 local p_para_ang = bind_param("AUTOB_PARA_ANG")
 local p_para_timeout = bind_param("AUTOB_PARA_TOUT")
+local p_loop_ms = bind_param("AUTOB_LOOP_MS")
+local p_win_s   = bind_param("AUTOB_WIN_TIM")
+local p_win_n   = bind_param("AUTOB_WIN_SMP")
+local p_dbg_en = bind_param("AUTOB_DBG_EN")
 
 -- Read Parachute trigger channel number from FCU parameter list 
 
@@ -49,24 +60,38 @@ local AUTOBAILOUT_EXCLUDE_MODES = {
 -- 5. STATE VARIABLES
 local active = false
 local last_mode_idx = 0
+local pre_bailout_mode = nil
 local first_pitch_exceeded_t = nil
+local gcs_announce_autobailout = false
+
+local WINDOW_SIZE     = 50
+local pitch_error_buf = {}
+local pitch_angle_buf = {}
+local buf_idx         = 1
+
+local function buf_avg(buf)
+    local sum, count = 0, 0
+    for _, v in pairs(buf) do sum = sum + v; count = count + 1 end
+    if count == 0 then return 0 end
+    return sum / count
+end
+
+local function buf_max(buf)
+    local mx = -math.huge
+    for _, v in pairs(buf) do if v > mx then mx = v end end
+    if mx == -math.huge then return 0 end
+    return mx
+end
 
 -- Parachute state variables
 local trigger_para_script = false
 local first_para_pitch_exceeded_t = nil
 local PARA_CHAN_HIGH = 1850
+local last_para_warn_t = 0 
 local backtransition_complete_time_ms = nil
 
 -- Helper: Radians to Degrees
 local function rad2deg(r) return r * 57.2958 end
-
-function is_vehicle_landing()
-    if quadplane:in_vtol_land_descent() then
-        return true
-    else
-        return false
-    end
-end
 
 function in_vtol_flight()
     local mode = vehicle:get_mode()
@@ -98,11 +123,24 @@ function para_deploy()
     if PARA_TRIG_CHAN then
         channel_num = PARA_TRIG_CHAN:get()
         -- gcs:send_text(2, "Channel num" .. tostring(channel_num))
+        if channel_num == nil then
+            local t = millis():tofloat()
+            if (t - last_para_warn_t) > 3000 then
+                gcs:send_text(2, "AUTOB: PARA_TRIG_CH not set")
+                last_para_warn_t = t
+            end
+            return
+        end  
+
         para_trigger_rc_chan = rc:get_channel(channel_num)
     end
 
     if para_trigger_rc_chan == nil then
-        gcs:send_text(2, "AUTOB:Para rc channel is nil")
+        local t = millis():tofloat()
+        if (t - last_para_warn_t) > 3000 then
+            gcs:send_text(2, "AUTOB:Para rc channel is nil")
+            last_para_warn_t = t
+        end
         return
     end
     
@@ -137,21 +175,55 @@ function para_deploy()
 end
 
 function update()
+    local loop_ms = p_loop_ms:get() or 100
     para_deploy()
-    if trigger_para_script then return  update, LOOP_MS end
+    if trigger_para_script then return  update, loop_ms end
 
     -- Safety Check
-    if p_enable:get() ~= 1 then return update, LOOP_MS end
+    if p_enable:get() ~= 1 then return update, loop_ms end
 
     local current_mode = vehicle:get_mode()
-    if not current_mode then return update, LOOP_MS end
+    if not current_mode then return update, loop_ms end
 
     local now = millis():tofloat()
 
     -- Detect Mode Changes
     if current_mode ~= last_mode_idx then
-        last_mode_idx = current_mode
-        first_pitch_exceeded_t = nil
+            last_mode_idx = current_mode
+            first_pitch_exceeded_t = nil
+            if not active then        -- ADD THIS GUARD
+                pitch_error_buf = {}
+                pitch_angle_buf = {}
+                buf_idx = 1
+            end
+    end
+
+    local win_n   = math.max(1, math.floor((p_win_s:get() or 5) * 1000 / loop_ms))
+    if win_n ~= WINDOW_SIZE then
+        WINDOW_SIZE = win_n
+        if not active then
+            pitch_error_buf = {}
+            pitch_angle_buf = {}
+            buf_idx = 1
+        end
+        p_win_n:set(WINDOW_SIZE)
+    end
+
+    local desired          = qp_att_desired()
+    local actual           = qp_att_actual()
+    local target_pitch_deg = desired and (desired.pitch_cd * 0.01) or 0
+    local actual_pitch_deg = actual  and (actual.pitch_cd  * 0.01) or 0
+
+    pitch_error_buf[buf_idx] = math.abs(target_pitch_deg - actual_pitch_deg)
+    pitch_angle_buf[buf_idx] = math.abs(actual_pitch_deg)
+    buf_idx = (buf_idx % WINDOW_SIZE) + 1
+
+    local avg_err  = buf_avg(pitch_error_buf)
+    local peak_ang = buf_max(pitch_angle_buf)
+    local pitch_deg = rad2deg(ahrs:get_pitch() or 0)
+
+    if p_dbg_en:get() == 1 then
+        logger:write('AUTB', 'AvgErr,PeakAng,PitchDeg', 'fff', avg_err, peak_ang, pitch_deg)
     end
 
     -- ==========================================================
@@ -164,7 +236,7 @@ function update()
             if backtransition_complete_time_ms and (now - backtransition_complete_time_ms) > delay_ms then
                 local pitch_deg = rad2deg(ahrs:get_pitch() or 0)
                 local threshold = p_pit_lim:get() or 40
-                local pitch_timeout = p_pitch_timeout:get() or 500
+                local pitch_timeout = p_pitch_timeout:get() or 100
                 if pitch_deg < threshold then
                     if first_pitch_exceeded_t == nil then
                         first_pitch_exceeded_t = millis():tofloat()
@@ -174,23 +246,42 @@ function update()
                             if vehicle:set_mode(MODE_QLOITER) then
                                 first_pitch_exceeded_t = nil
                                 active = true
+                                pre_bailout_mode = current_mode
                                 gcs:send_text(2, "AUTOB: Switching to QLoiter" )
                             end
                         end
                     end
                 else
                     first_pitch_exceeded_t = nil
-                end
+                end          
             end
         end
     elseif active then
-        -- Cancel if pilot manually switched mode
+        if not gcs_announce_autobailout then
+            gcs:send_text(2, "AUTOB: Autobailout Active")
+            gcs_announce_autobailout = true
+        end
         if current_mode ~= MODE_QLOITER then
             active = false
+            pre_bailout_mode = nil
+            gcs_announce_autobailout = false
             gcs:send_text(6, "AUTOB: Manual Override Detected")
+        else
+            local avg_lim  = p_avg_lim:get()  or 20
+            local peak_lim = p_peak_lim:get() or 30
+            if avg_err < avg_lim and peak_ang < peak_lim then
+                if pre_bailout_mode and vehicle:set_mode(pre_bailout_mode) then
+                    local recovered_mode = pre_bailout_mode
+                    active = false
+                    pre_bailout_mode = nil
+                    gcs_announce_autobailout = false
+                    gcs:send_text(2, "AUTOB: Recovering to mode " .. tostring(recovered_mode))
+                end
+            end
         end
+
     end
-    return update, LOOP_MS
+    return update, loop_ms
 
 end
 


### PR DESCRIPTION
… max pitch angle and continue into inital mode after stability is re-established

This update in the lua script is to control how the UAV exits an auto bailout situation

following is the condition for the uav to enter autobailout condition

Initial mode = QRTL
if (AHRS_Pitch > AUTOB_PIT_LIM) Mode = Qloiter 

following is the new condition to exit auto bailout condition

if (rolling pitch error avg < AUTOB_AVG_LIM and pitch_max < AUTOB_PEAK_LIM)
mode = initial mode

some added parameters in the lua

- AUTOB_AVG_LIM - average maximum rolling average pitch error
- AUTOB_PEAK_LIM - maximum pitch angle
- AUTOB_WIN_TIM - time in seconds over which pitch error and pitch angle samples are collected
- AUTOB_WIN_SMP - number of samples taken in AUTOB_WIN_TIM ( This is automatically calculated in the code and need not be changed)
- AUTOB_DBG_EN - enables / disables logging of avg angle, max pitch angle, pitch angle onto dataflash LOGs, data shows up under AUTB

Notion Page:
https://app.notion.com/p/airbound/Resume-post-Auto-Bailout-Lua-with-rolling-average-pitch-error-37921adf4be980cda661fedadb840bbe
The below notion page tracks the test cases
https://app.notion.com/p/airbound/Resume-mission-after-autobailout-38121adf4be980298658edbf40d8c4f5?source=copy_link
