### PR TITLE
Fix feedforward_scalar logic

### DIFF
--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -809,7 +809,7 @@ void AC_AttitudeControl::attitude_controller_run_quat()
         _ang_vel_body.z = _ahrs.get_gyro().z;
         get_rate_yaw_pid().reset_I();
     } else if (_thrust_error_angle > AC_ATTITUDE_THRUST_ERROR_ANGLE * 2.0f) {
-        _feedforward_scalar = (1.0f - (_thrust_error_angle - AC_ATTITUDE_THRUST_ERROR_ANGLE*2) / AC_ATTITUDE_THRUST_ERROR_ANGLE);
+        _feedforward_scalar = (1.0f - (_thrust_error_angle - AC_ATTITUDE_THRUST_ERROR_ANGLE * 2.0f) / AC_ATTITUDE_THRUST_ERROR_ANGLE);
         _ang_vel_body.x += ang_vel_body_feedforward.x * _feedforward_scalar;
         _ang_vel_body.y += ang_vel_body_feedforward.y * _feedforward_scalar;
         _ang_vel_body.z += ang_vel_body_feedforward.z;

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -809,7 +809,7 @@ void AC_AttitudeControl::attitude_controller_run_quat()
         _ang_vel_body.z = _ahrs.get_gyro().z;
         get_rate_yaw_pid().reset_I();
     } else if (_thrust_error_angle > AC_ATTITUDE_THRUST_ERROR_ANGLE * 2.0f) {
-        _feedforward_scalar = (1.0f - (_thrust_error_angle - AC_ATTITUDE_THRUST_ERROR_ANGLE) / AC_ATTITUDE_THRUST_ERROR_ANGLE);
+        _feedforward_scalar = (1.0f - (_thrust_error_angle - AC_ATTITUDE_THRUST_ERROR_ANGLE*2) / AC_ATTITUDE_THRUST_ERROR_ANGLE);
         _ang_vel_body.x += ang_vel_body_feedforward.x * _feedforward_scalar;
         _ang_vel_body.y += ang_vel_body_feedforward.y * _feedforward_scalar;
         _ang_vel_body.z += ang_vel_body_feedforward.z;


### PR DESCRIPTION
Fixes the feedforward scalar calculation when the yaw exceeds the limits 
https://app.notion.com/p/airbound/Change-the-thrust-error-angle-yaw-disabling-thresholds-37b21adf4be9806bb529fe8287880497?source=copy_link