### PR TITLE
autobailout: Add rate based vtol pitch prediction

### DIFF
--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,7 +6,7 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "AB ArduPlane V4.5.7.5 - rc5-fixes"
+#define THISFIRMWARE "AB ArduPlane V4.5.7.5 - rc6-fixes-autobv4"
 
 // the following line is parsed by the autotest scripts
 #define FIRMWARE_VERSION 4,5,7,FIRMWARE_VERSION_TYPE_DEV

--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
@@ -148,7 +148,7 @@ function para_deploy()
         return
     end
     
-    para_threshold = p_para_ang:get() or -45
+    local para_threshold = p_para_ang:get() or -45
     if not is_parachute_angle_threshold_valid(para_threshold) then
         gcs:send_text(2, string.format("AUTOB:AUTB_PARA_ANG invalid. Range(%.1f, %.1f)",para_ahrs_pitch_threshold_min, para_ahrs_pitch_threshold_max))    
         return
@@ -194,37 +194,62 @@ function trigger_autobailout(current_mode)
     return false
 end
 
-function is_vtol_pitch_within_limits(pitch)
+function is_vtol_pitch_exceeding_limit(vtolpitch, is_vtol_flight)
     local threshold = p_pit_lim:get() or 40
     local pitch_timeout = p_pitch_timeout:get() or 100
     
     --dont check if not armed or not in vtol phase
-    if not in_vtol_flight() or not arming:is_armed() then
+    if not is_vtol_flight or not arming:is_armed() then
         -- Wait for Delay (settle time)
-        return true
+        return false
     end
     
     --dont check if within delay_ms post backtransition
     local delay_ms = p_btrn_dly:get() or 1000
     if backtransition_complete_time_ms and (now - backtransition_complete_time_ms) < delay_ms then
-        return true
+        return false
     end
     
-    if math.abs(pitch) > threshold then
+    if math.abs(vtolpitch) > threshold then
         if first_pitch_exceeded_t == nil then
             first_pitch_exceeded_t = millis():tofloat()
         else
             local time_diff = now - first_pitch_exceeded_t
             if time_diff > pitch_timeout then
-                first_pitch_exceeded_t = nil   
-                return false     
+                first_pitch_exceeded_t = nil  
+                gcs:send_text(2, "AUTOB: VTOL pitch exceeding threshold")
+                return true     
             end
         end
     else
         first_pitch_exceeded_t = nil
     end
-    return true
+    return false
 end    
+
+function is_predicted_vtol_pitch_exceeding_parathreshold(current_vtol_pitch_deg, current_vtol_pitch_rate, is_vtol_flight)
+    local pitch_prediction_interval = p_prediction_interval:get() or 0
+    --convert to VTOL frame
+    local para_threshold = 90 - (p_para_ang:get() or -45) 
+
+    if not is_vtol_flight or not arming:is_armed() then
+        -- Wait for Delay (settle time)
+        return false
+    end
+    
+    --dont check if within delay_ms post backtransition
+    local delay_ms = p_btrn_dly:get() or 1000
+    if backtransition_complete_time_ms and (now - backtransition_complete_time_ms) < delay_ms then
+        return false
+    end
+
+    local predicted_next_instance_vtol_pitch = current_vtol_pitch_deg + current_vtol_pitch_rate * (pitch_prediction_interval/1000)
+    if math.abs(predicted_next_instance_vtol_pitch) > para_threshold then
+        gcs:send_text(2, "AUTOB: PredPitch exceeds limit: " .. tostring(predicted_next_instance_vtol_pitch))
+        return true
+    end
+    return false
+end
 
 function update()
     local loop_ms = p_loop_ms:get() or 100
@@ -266,9 +291,7 @@ function update()
     local target_vtol_pitch_deg = desired and (desired.pitch_cd * 0.01) or 0
     local actual_vtol_pitch_deg = actual  and (actual.pitch_cd  * 0.01) or 0
     local vtol_pitch_rate_pid = qp_rate_pid_info(1)
-    local current_instance_vtol_pitch_rate =  vtol_pitch_rate_pid and rad2deg(vtol_pitch_rate_pid.actual or 0) or 0
-    local pitch_prediction_interval = p_prediction_interval:get() or 0
-    local predicted_next_instance_vtol_pitch = actual_vtol_pitch_deg + current_instance_vtol_pitch_rate * pitch_prediction_interval/1000
+    local actual_vtol_pitch_rate =  vtol_pitch_rate_pid and rad2deg(vtol_pitch_rate_pid.actual or 0) or 0
 
     pitch_error_buf[buf_idx] = math.abs(target_vtol_pitch_deg - actual_vtol_pitch_deg)
     pitch_angle_buf[buf_idx] = math.abs(actual_vtol_pitch_deg)
@@ -279,16 +302,22 @@ function update()
     local pitch_deg = rad2deg(ahrs:get_pitch() or 0)
 
     if p_dbg_en:get() == 1 then
-        logger:write('AUTB', 'AvgErr,PeakAng,PitchDeg,QPredPit', 'ffff', avg_err, peak_ang, pitch_deg,predicted_next_instance_vtol_pitch)
+        logger:write('AUTB', 'AvgErr,PeakAng,PitchDeg,QPit,QRateP', 'fffff', avg_err, peak_ang, pitch_deg, actual_vtol_pitch_deg, actual_vtol_pitch_rate)
     end
-
+    
+    is_vtol_flight = in_vtol_flight()
     -- ==========================================================
     -- LOGIC: MONITORING (Checking Pitch)
     -- ==========================================================
     if not autobailout_active then
-        if not is_vtol_pitch_within_limits(actual_vtol_pitch_deg) then
+        if is_vtol_pitch_exceeding_limit(actual_vtol_pitch_deg, is_vtol_flight) then
+            trigger_autobailout(current_mode)
+        elseif is_predicted_vtol_pitch_exceeding_parathreshold(actual_vtol_pitch_deg, actual_vtol_pitch_rate, is_vtol_flight) then
             trigger_autobailout(current_mode)
         end
+    -- ==========================================================
+    -- LOGIC: RECOVERY
+    -- ==========================================================
     elseif autobailout_active then
         if not gcs_announce_autobailout then
             gcs:send_text(2, "AUTOB: Autobailout Active")

--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
@@ -264,7 +264,7 @@ function is_predicted_vtol_pitch_exceeding_parathreshold(current_vtol_pitch_deg,
     local predicted_next_instance_vtol_pitch = current_vtol_pitch_deg + current_vtol_pitch_rate * (pitch_prediction_interval/1000)
 
     if math.abs(predicted_next_instance_vtol_pitch) > para_threshold then
-        gcs:send_text(2, "AUTOB: PredPitch exceeds threshold: " .. tostring(predicted_next_instance_vtol_pitch))
+        gcs:send_text(2, "AUTOB: PredPitch exceeds Parathresh: " .. tostring(predicted_next_instance_vtol_pitch))
         return true
     end
     return false

--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
@@ -8,19 +8,19 @@ local KEY = 110
 assert(param:add_table(KEY, "AUTOB_", 14), "AUTOB table failed")
 
 -- 2. ADD PARAMETERS
-assert(param:add_param(KEY, 1, "PIT_LIM",  40),  'could not add AUTOB_PIT_LIM')   -- AHRS pitch threshold to enter bailout (deg)
+assert(param:add_param(KEY, 1, "PIT_LIM",  50),  'could not add AUTOB_PIT_LIM')   -- ATT pitch(VTOL frame) threshold to enter bailout (deg)
 assert(param:add_param(KEY, 2, "ENABLE", 1),'could not add AUTOB_ENABLE')    -- 1 = Enabled
 assert(param:add_param(KEY, 3, "BTRN_DLY", 2500), 'could not add AUTOB_BTRN_DLY') -- Delay (ms) before checking pitch
 assert(param:add_param(KEY, 4, "PIT_TOUT", 100), 'could not add AUTOB_PIT_TOUT')  -- Sustained duration to enter bailout (ms)
 assert(param:add_param(KEY, 5, "PARA_EN", 1),'could not add AUTOB_PARA_EN')    -- 1 = Enabled
-assert(param:add_param(KEY, 6,"PARA_ANG", -15),'could not add AUTOB_PARA_ANG')
-assert(param:add_param(KEY, 7,"PARA_TOUT", 100),'could not add AUTOB_PARA_TOUT')
+assert(param:add_param(KEY, 6,"PARA_ANG", -15),'could not add AUTOB_PARA_ANG') -- AHRS Pitch(FW frame) threshold to trigger parachute(deg)
+assert(param:add_param(KEY, 7,"PARA_TOUT", 100),'could not add AUTOB_PARA_TOUT') -- Parachute pitch threshold timeout in ms
 assert(param:add_param(KEY, 8,  "LOOP_MS", 50), 'could not add AUTOB_LOOP_MS')  -- Loop rate (ms)
 assert(param:add_param(KEY, 9,  "WIN_TIM",   5),   'could not add AUTOB_WIN_TIM')    -- Rolling window duration (s)
 assert(param:add_param(KEY, 10, "WIN_SMP",   50),  'could not add AUTOB_WIN_SMP')    -- Calculated samples (output, read-only)
 assert(param:add_param(KEY, 11,  "AVG_LIM", 20),'could not add AUTOB_AVG_LIM')    -- Pitch limit
 assert(param:add_param(KEY, 12,"PEAK_LIM", 30),'could not add AUTOB_PEAK_LIM')
-assert(param:add_param(KEY, 13, "DBG_EN", 0), 'could not add AUTOB_DBG_EN')  -- 1 = enable dataflash logging
+assert(param:add_param(KEY, 13, "DBG_EN", 1), 'could not add AUTOB_DBG_EN')  -- 1 = enable dataflash logging
 assert(param:add_param(KEY, 14, "PRED_INT", 500), 'could not add AUTOB_PRED_INT')  -- Rate based VTOL pitch prediction interval
 
 -- 3. BIND PARAMETERS

--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
@@ -5,7 +5,7 @@ local para_ahrs_pitch_threshold_min = -50
 
 -- 1. SETUP PARAMETER TABLE
 local KEY = 110
-assert(param:add_table(KEY, "AUTOB_", 14), "AUTOB table failed")
+assert(param:add_table(KEY, "AUTOB_", 15), "AUTOB table failed")
 
 -- 2. ADD PARAMETERS
 assert(param:add_param(KEY, 1, "PIT_LIM",  50),  'could not add AUTOB_PIT_LIM')   -- ATT pitch(VTOL frame) threshold to enter bailout (deg)
@@ -22,6 +22,7 @@ assert(param:add_param(KEY, 11,  "AVG_LIM", 20),'could not add AUTOB_AVG_LIM')  
 assert(param:add_param(KEY, 12,"PEAK_LIM", 30),'could not add AUTOB_PEAK_LIM')
 assert(param:add_param(KEY, 13, "DBG_EN", 1), 'could not add AUTOB_DBG_EN')  -- 1 = enable dataflash logging
 assert(param:add_param(KEY, 14, "PRED_INT", 500), 'could not add AUTOB_PRED_INT')  -- Rate based VTOL pitch prediction interval
+assert(param:add_param(KEY, 15, "PRED_ANG", 105), 'could not add AUTOB_PRED_ANG') -- VTOL frame absolute rate based predicted angle threshold for autobailout
 
 -- 3. BIND PARAMETERS
 local function bind_param(name)
@@ -46,6 +47,7 @@ local p_win_s   = bind_param("AUTOB_WIN_TIM")
 local p_win_n   = bind_param("AUTOB_WIN_SMP")
 local p_dbg_en = bind_param("AUTOB_DBG_EN")
 local p_prediction_interval = bind_param("AUTOB_PRED_INT")
+local p_pred_angle_threshold = bind_param("AUTOB_PRED_ANG")
 
 -- Read Parachute trigger channel number from FCU parameter list 
 
@@ -232,7 +234,7 @@ function is_vtol_pitch_exceeding_limit(vtolpitch, is_vtol_flight, flightmode)
     return false
 end    
 
-function is_predicted_vtol_pitch_exceeding_parathreshold(current_vtol_pitch_deg, current_vtol_pitch_rate, is_vtol_flight, flightmode)
+function is_predicted_vtol_pitch_exceeding_threshold(current_vtol_pitch_deg, current_vtol_pitch_rate, is_vtol_flight, flightmode)
     local pitch_prediction_interval = p_prediction_interval:get() or 0
 
     --Disable prediction based check
@@ -245,8 +247,7 @@ function is_predicted_vtol_pitch_exceeding_parathreshold(current_vtol_pitch_deg,
         return false
     end
 
-    --convert to VTOL frame
-    local para_threshold = 90 - (p_para_ang:get() or -45) 
+    local predicted_angle_threshold = p_pred_angle_threshold:get() or 105
 
     if not is_vtol_flight or not arming:is_armed() then
         -- Wait for Delay (settle time)
@@ -262,8 +263,8 @@ function is_predicted_vtol_pitch_exceeding_parathreshold(current_vtol_pitch_deg,
     
     local predicted_next_instance_vtol_pitch = current_vtol_pitch_deg + current_vtol_pitch_rate * (pitch_prediction_interval/1000)
 
-    if math.abs(predicted_next_instance_vtol_pitch) > para_threshold then
-        gcs:send_text(2, "AUTOB: PredPitch exceeds Parathresh: " .. tostring(predicted_next_instance_vtol_pitch))
+    if math.abs(predicted_next_instance_vtol_pitch) > predicted_angle_threshold then
+        gcs:send_text(2, "AUTOB: PredPitch exceeds thresh: " .. tostring(predicted_next_instance_vtol_pitch))
         return true
     end
     return false
@@ -328,7 +329,7 @@ function update()
     if not autobailout_active then
         if is_vtol_pitch_exceeding_limit(actual_vtol_pitch_deg, is_vtol_flight, current_mode) then
             trigger_autobailout(current_mode)
-        elseif is_predicted_vtol_pitch_exceeding_parathreshold(actual_vtol_pitch_deg, actual_vtol_pitch_rate, is_vtol_flight,current_mode) then
+        elseif is_predicted_vtol_pitch_exceeding_threshold(actual_vtol_pitch_deg, actual_vtol_pitch_rate, is_vtol_flight,current_mode) then
             trigger_autobailout(current_mode)
         end
     -- ==========================================================

--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
@@ -210,6 +210,10 @@ function is_vtol_pitch_exceeding_limit(vtolpitch, is_vtol_flight, flightmode)
         return false
     end
     
+    if threshold < 0 then
+        return false
+    end
+
     --dont check if within delay_ms post backtransition
     local current_time = millis():tofloat()
     local delay_ms = p_btrn_dly:get() or 1000

--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
@@ -210,7 +210,8 @@ function is_vtol_pitch_exceeding_limit(vtolpitch, is_vtol_flight, flightmode)
         return false
     end
     
-    if threshold < 0 then
+    --Dont monitor vtol pitch if AUTOB_PIT_LIM is negative.
+    if pitch_timeout < 0 then
         return false
     end
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
@@ -5,7 +5,7 @@ local para_ahrs_pitch_threshold_min = -50
 
 -- 1. SETUP PARAMETER TABLE
 local KEY = 110
-assert(param:add_table(KEY, "AUTOB_", 13), "AUTOB table failed")
+assert(param:add_table(KEY, "AUTOB_", 14), "AUTOB table failed")
 
 -- 2. ADD PARAMETERS
 assert(param:add_param(KEY, 1, "PIT_LIM",  40),  'could not add AUTOB_PIT_LIM')   -- AHRS pitch threshold to enter bailout (deg)
@@ -21,6 +21,7 @@ assert(param:add_param(KEY, 10, "WIN_SMP",   50),  'could not add AUTOB_WIN_SMP'
 assert(param:add_param(KEY, 11,  "AVG_LIM", 20),'could not add AUTOB_AVG_LIM')    -- Pitch limit
 assert(param:add_param(KEY, 12,"PEAK_LIM", 30),'could not add AUTOB_PEAK_LIM')
 assert(param:add_param(KEY, 13, "DBG_EN", 0), 'could not add AUTOB_DBG_EN')  -- 1 = enable dataflash logging
+assert(param:add_param(KEY, 14, "PRED_INT", 500), 'could not add AUTOB_DBG_EN')  -- Rate based VTOL pitch prediction interval
 
 -- 3. BIND PARAMETERS
 local function bind_param(name)
@@ -44,6 +45,7 @@ local p_loop_ms = bind_param("AUTOB_LOOP_MS")
 local p_win_s   = bind_param("AUTOB_WIN_TIM")
 local p_win_n   = bind_param("AUTOB_WIN_SMP")
 local p_dbg_en = bind_param("AUTOB_DBG_EN")
+local p_prediction_interval = bind_param("AUTOB_PRED_INT")
 
 -- Read Parachute trigger channel number from FCU parameter list 
 
@@ -212,11 +214,15 @@ function update()
 
     local desired          = qp_att_desired()
     local actual           = qp_att_actual()
-    local target_pitch_deg = desired and (desired.pitch_cd * 0.01) or 0
-    local actual_pitch_deg = actual  and (actual.pitch_cd  * 0.01) or 0
+    local target_vtol_pitch_deg = desired and (desired.pitch_cd * 0.01) or 0
+    local actual_vtol_pitch_deg = actual  and (actual.pitch_cd  * 0.01) or 0
+    local vtol_pitch_rate_pid = qp_rate_pid_info(1)
+    local current_instance_vtol_pitch_rate = rad2deg(vtol_pitch_rate_pid.actual or 0)
+    local pitch_prediction_interval = p_prediction_interval:get() or 0
+    local predicted_next_instance_vtol_pitch = actual_vtol_pitch_deg + current_instance_vtol_pitch_rate * pitch_prediction_interval/1000
 
-    pitch_error_buf[buf_idx] = math.abs(target_pitch_deg - actual_pitch_deg)
-    pitch_angle_buf[buf_idx] = math.abs(actual_pitch_deg)
+    pitch_error_buf[buf_idx] = math.abs(target_vtol_pitch_deg - actual_vtol_pitch_deg)
+    pitch_angle_buf[buf_idx] = math.abs(actual_vtol_pitch_deg)
     buf_idx = (buf_idx % WINDOW_SIZE) + 1
 
     local avg_err  = buf_avg(pitch_error_buf)
@@ -224,7 +230,7 @@ function update()
     local pitch_deg = rad2deg(ahrs:get_pitch() or 0)
 
     if p_dbg_en:get() == 1 then
-        logger:write('AUTB', 'AvgErr,PeakAng,PitchDeg', 'fff', avg_err, peak_ang, pitch_deg)
+        logger:write('AUTB', 'AvgErr,PeakAng,PitchDeg,QPredPit', 'ffff', avg_err, peak_ang, pitch_deg,predicted_next_instance_vtol_pitch)
     end
 
     -- ==========================================================
@@ -235,10 +241,9 @@ function update()
             -- Wait for Delay (settle time)
             local delay_ms = p_btrn_dly:get() or 1000
             if backtransition_complete_time_ms and (now - backtransition_complete_time_ms) > delay_ms then
-                local pitch_deg = rad2deg(ahrs:get_pitch() or 0)
                 local threshold = p_pit_lim:get() or 40
                 local pitch_timeout = p_pitch_timeout:get() or 100
-                if pitch_deg < threshold then
+                if math.abs(predicted_next_instance_vtol_pitch) > threshold then
                     if first_pitch_exceeded_t == nil then
                         first_pitch_exceeded_t = millis():tofloat()
                     else

--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
@@ -60,7 +60,7 @@ local AUTOBAILOUT_EXCLUDE_MODES = {
     [23] = true,  -- QACRO
 }
 -- 5. STATE VARIABLES
-local active = false
+local autobailout_active = false
 local last_mode_idx = 0
 local pre_bailout_mode = nil
 local first_pitch_exceeded_t = nil
@@ -118,6 +118,7 @@ function is_parachute_angle_threshold_valid(threshold_angle)
 end
 
 function para_deploy()
+    
     if p_para_enable:get() ~= 1 then return end
 
     para_trigger_rc_chan = nil
@@ -177,6 +178,54 @@ function para_deploy()
     end
 end
 
+function trigger_autobailout(current_mode)
+    if autobailout_active then
+        gcs:send_text(2, "AUTOB: Autobailout already active")
+        gcs:send_text(2, "AUTOB: Trigger rejected")
+        return false
+    end
+    if vehicle:set_mode(MODE_QLOITER) then
+        autobailout_active = true
+        pre_bailout_mode = current_mode
+        post_bailout_sample_count = 0 --Reset this variable only when autobailout is active
+        gcs:send_text(2, "AUTOB: Switching to QLoiter" )
+        return true
+    end
+    return false
+end
+
+function is_vtol_pitch_within_limits(pitch)
+    local threshold = p_pit_lim:get() or 40
+    local pitch_timeout = p_pitch_timeout:get() or 100
+    
+    --dont check if not armed or not in vtol phase
+    if not in_vtol_flight() or not arming:is_armed() then
+        -- Wait for Delay (settle time)
+        return true
+    end
+    
+    --dont check if within delay_ms post backtransition
+    local delay_ms = p_btrn_dly:get() or 1000
+    if backtransition_complete_time_ms and (now - backtransition_complete_time_ms) < delay_ms then
+        return true
+    end
+    
+    if math.abs(pitch) > threshold then
+        if first_pitch_exceeded_t == nil then
+            first_pitch_exceeded_t = millis():tofloat()
+        else
+            local time_diff = now - first_pitch_exceeded_t
+            if time_diff > pitch_timeout then
+                first_pitch_exceeded_t = nil   
+                return false     
+            end
+        end
+    else
+        first_pitch_exceeded_t = nil
+    end
+    return true
+end    
+
 function update()
     local loop_ms = p_loop_ms:get() or 100
     para_deploy()
@@ -194,7 +243,7 @@ function update()
     if current_mode ~= last_mode_idx then
         last_mode_idx = current_mode
         first_pitch_exceeded_t = nil
-        if not active then        -- ADD THIS GUARD
+        if not autobailout_active then        -- ADD THIS GUARD
             pitch_error_buf = {}
             pitch_angle_buf = {}
             buf_idx = 1
@@ -204,7 +253,7 @@ function update()
     local win_n   = math.max(1, math.floor((p_win_s:get() or 5) * 1000 / loop_ms))
     if win_n ~= WINDOW_SIZE then
         WINDOW_SIZE = win_n
-        if not active then
+        if not autobailout_active then
             pitch_error_buf = {}
             pitch_angle_buf = {}
             buf_idx = 1
@@ -236,40 +285,17 @@ function update()
     -- ==========================================================
     -- LOGIC: MONITORING (Checking Pitch)
     -- ==========================================================
-    if not active then
-        if in_vtol_flight() and arming:is_armed() then
-            -- Wait for Delay (settle time)
-            local delay_ms = p_btrn_dly:get() or 1000
-            if backtransition_complete_time_ms and (now - backtransition_complete_time_ms) > delay_ms then
-                local threshold = p_pit_lim:get() or 40
-                local pitch_timeout = p_pitch_timeout:get() or 100
-                if math.abs(predicted_next_instance_vtol_pitch) > threshold then
-                    if first_pitch_exceeded_t == nil then
-                        first_pitch_exceeded_t = millis():tofloat()
-                    else
-                        time_diff = now - first_pitch_exceeded_t
-                        if time_diff > pitch_timeout then
-                            if vehicle:set_mode(MODE_QLOITER) then
-                                first_pitch_exceeded_t = nil
-                                active = true
-                                pre_bailout_mode = current_mode
-                                post_bailout_sample_count = 0 --Reset this variable only when autobailout is active
-                                gcs:send_text(2, "AUTOB: Switching to QLoiter" )
-                            end
-                        end
-                    end
-                else
-                    first_pitch_exceeded_t = nil
-                end          
-            end
+    if not autobailout_active then
+        if not is_vtol_pitch_within_limits(actual_vtol_pitch_deg) then
+            trigger_autobailout(current_mode)
         end
-    elseif active then
+    elseif autobailout_active then
         if not gcs_announce_autobailout then
             gcs:send_text(2, "AUTOB: Autobailout Active")
             gcs_announce_autobailout = true
         end
         if current_mode ~= MODE_QLOITER then
-            active = false
+            autobailout_active = false
             pre_bailout_mode = nil
             gcs_announce_autobailout = false
             gcs:send_text(6, "AUTOB: Manual Override Detected")
@@ -281,7 +307,7 @@ function update()
             if post_bailout_sample_count >= WINDOW_SIZE and avg_err < avg_lim and peak_ang < peak_lim then
                 if pre_bailout_mode and vehicle:set_mode(pre_bailout_mode) then
                     local recovered_mode = pre_bailout_mode
-                    active = false
+                    autobailout_active = false
                     pre_bailout_mode = nil
                     gcs_announce_autobailout = false
                     gcs:send_text(2, "AUTOB: Recovering to mode " .. tostring(recovered_mode))

--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
@@ -21,7 +21,7 @@ assert(param:add_param(KEY, 10, "WIN_SMP",   50),  'could not add AUTOB_WIN_SMP'
 assert(param:add_param(KEY, 11,  "AVG_LIM", 20),'could not add AUTOB_AVG_LIM')    -- Pitch limit
 assert(param:add_param(KEY, 12,"PEAK_LIM", 30),'could not add AUTOB_PEAK_LIM')
 assert(param:add_param(KEY, 13, "DBG_EN", 1), 'could not add AUTOB_DBG_EN')  -- 1 = enable dataflash logging
-assert(param:add_param(KEY, 14, "PRED_INT", 500), 'could not add AUTOB_PRED_INT')  -- Rate based VTOL pitch prediction interval
+assert(param:add_param(KEY, 14, "PRED_INT", 1000), 'could not add AUTOB_PRED_INT')  -- Rate based VTOL pitch prediction interval
 assert(param:add_param(KEY, 15, "PRED_ANG", 105), 'could not add AUTOB_PRED_ANG') -- VTOL frame absolute rate based predicted angle threshold for autobailout
 
 -- 3. BIND PARAMETERS

--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
@@ -98,7 +98,7 @@ local function rad2deg(r) return r * 57.2958 end
 
 function in_vtol_flight()
     local mode = vehicle:get_mode()
-    local vtol_active = not quadplane:tailsitter_in_vtol_transition() and quadplane:in_vtol_mode() and not AUTOBAILOUT_EXCLUDE_MODES[mode]
+    local vtol_active = not quadplane:tailsitter_in_vtol_transition() and quadplane:in_vtol_mode()
     if vtol_active then
         if backtransition_complete_time_ms == nil then
             backtransition_complete_time_ms = millis():tofloat()
@@ -154,7 +154,7 @@ function para_deploy()
         return
     end
 
-    now = millis():tofloat()
+    local now = millis():tofloat()
     ahrs_pitch = rad2deg(ahrs:get_pitch() or 0)
     para_ang_timeout = p_para_timeout:get() or 200
     check_pitch = ahrs_pitch < para_threshold and (trigger_para_script == false) and quadplane:in_vtol_mode() and arming:is_armed()
@@ -194,9 +194,14 @@ function trigger_autobailout(current_mode)
     return false
 end
 
-function is_vtol_pitch_exceeding_limit(vtolpitch, is_vtol_flight)
+function is_vtol_pitch_exceeding_limit(vtolpitch, is_vtol_flight, flightmode)
     local threshold = p_pit_lim:get() or 40
     local pitch_timeout = p_pitch_timeout:get() or 100
+
+    --Dont check for pitch in AUTOBAILOUT_EXCLUDE_MODES
+    if AUTOBAILOUT_EXCLUDE_MODES[flightmode] then
+        return false
+    end
     
     --dont check if not armed or not in vtol phase
     if not is_vtol_flight or not arming:is_armed() then
@@ -205,16 +210,17 @@ function is_vtol_pitch_exceeding_limit(vtolpitch, is_vtol_flight)
     end
     
     --dont check if within delay_ms post backtransition
+    local current_time = millis():tofloat()
     local delay_ms = p_btrn_dly:get() or 1000
-    if backtransition_complete_time_ms and (now - backtransition_complete_time_ms) < delay_ms then
+    if backtransition_complete_time_ms and (current_time - backtransition_complete_time_ms) < delay_ms then
         return false
     end
-    
+
     if math.abs(vtolpitch) > threshold then
         if first_pitch_exceeded_t == nil then
             first_pitch_exceeded_t = millis():tofloat()
         else
-            local time_diff = now - first_pitch_exceeded_t
+            local time_diff = current_time - first_pitch_exceeded_t
             if time_diff > pitch_timeout then
                 first_pitch_exceeded_t = nil  
                 gcs:send_text(2, "AUTOB: VTOL pitch exceeding threshold: " .. tostring(vtolpitch))
@@ -227,8 +233,19 @@ function is_vtol_pitch_exceeding_limit(vtolpitch, is_vtol_flight)
     return false
 end    
 
-function is_predicted_vtol_pitch_exceeding_parathreshold(current_vtol_pitch_deg, current_vtol_pitch_rate, is_vtol_flight)
+function is_predicted_vtol_pitch_exceeding_parathreshold(current_vtol_pitch_deg, current_vtol_pitch_rate, is_vtol_flight, flightmode)
     local pitch_prediction_interval = p_prediction_interval:get() or 0
+
+    --Disable prediction based check
+    if pitch_prediction_interval < 0 then
+        return false
+    end
+
+    --Dont check for pitch in AUTOBAILOUT_EXCLUDE_MODES
+    if AUTOBAILOUT_EXCLUDE_MODES[flightmode] then
+        return false
+    end
+
     --convert to VTOL frame
     local para_threshold = 90 - (p_para_ang:get() or -45) 
 
@@ -238,12 +255,14 @@ function is_predicted_vtol_pitch_exceeding_parathreshold(current_vtol_pitch_deg,
     end
     
     --dont check if within delay_ms post backtransition
+    local current_time = millis():tofloat()
     local delay_ms = p_btrn_dly:get() or 1000
-    if backtransition_complete_time_ms and (now - backtransition_complete_time_ms) < delay_ms then
+    if backtransition_complete_time_ms and (current_time - backtransition_complete_time_ms) < delay_ms then
         return false
     end
-
+    
     local predicted_next_instance_vtol_pitch = current_vtol_pitch_deg + current_vtol_pitch_rate * (pitch_prediction_interval/1000)
+
     if math.abs(predicted_next_instance_vtol_pitch) > para_threshold then
         gcs:send_text(2, "AUTOB: PredPitch exceeds threshold: " .. tostring(predicted_next_instance_vtol_pitch))
         return true
@@ -261,8 +280,6 @@ function update()
 
     local current_mode = vehicle:get_mode()
     if not current_mode then return update, loop_ms end
-
-    local now = millis():tofloat()
 
     -- Detect Mode Changes
     if current_mode ~= last_mode_idx then
@@ -310,9 +327,9 @@ function update()
     -- LOGIC: MONITORING (Checking Pitch)
     -- ==========================================================
     if not autobailout_active then
-        if is_vtol_pitch_exceeding_limit(actual_vtol_pitch_deg, is_vtol_flight) then
+        if is_vtol_pitch_exceeding_limit(actual_vtol_pitch_deg, is_vtol_flight, current_mode) then
             trigger_autobailout(current_mode)
-        elseif is_predicted_vtol_pitch_exceeding_parathreshold(actual_vtol_pitch_deg, actual_vtol_pitch_rate, is_vtol_flight) then
+        elseif is_predicted_vtol_pitch_exceeding_parathreshold(actual_vtol_pitch_deg, actual_vtol_pitch_rate, is_vtol_flight,current_mode) then
             trigger_autobailout(current_mode)
         end
     -- ==========================================================

--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
@@ -217,7 +217,7 @@ function is_vtol_pitch_exceeding_limit(vtolpitch, is_vtol_flight)
             local time_diff = now - first_pitch_exceeded_t
             if time_diff > pitch_timeout then
                 first_pitch_exceeded_t = nil  
-                gcs:send_text(2, "AUTOB: VTOL pitch exceeding threshold")
+                gcs:send_text(2, "AUTOB: VTOL pitch exceeding threshold: " .. tostring(vtolpitch))
                 return true     
             end
         end
@@ -245,7 +245,7 @@ function is_predicted_vtol_pitch_exceeding_parathreshold(current_vtol_pitch_deg,
 
     local predicted_next_instance_vtol_pitch = current_vtol_pitch_deg + current_vtol_pitch_rate * (pitch_prediction_interval/1000)
     if math.abs(predicted_next_instance_vtol_pitch) > para_threshold then
-        gcs:send_text(2, "AUTOB: PredPitch exceeds limit: " .. tostring(predicted_next_instance_vtol_pitch))
+        gcs:send_text(2, "AUTOB: PredPitch exceeds threshold: " .. tostring(predicted_next_instance_vtol_pitch))
         return true
     end
     return false

--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
@@ -97,7 +97,6 @@ local backtransition_complete_time_ms = nil
 local function rad2deg(r) return r * 57.2958 end
 
 function in_vtol_flight()
-    local mode = vehicle:get_mode()
     local vtol_active = not quadplane:tailsitter_in_vtol_transition() and quadplane:in_vtol_mode()
     if vtol_active then
         if backtransition_complete_time_ms == nil then

--- a/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk6C-bdshot/scripts/autobailout.lua
@@ -21,7 +21,7 @@ assert(param:add_param(KEY, 10, "WIN_SMP",   50),  'could not add AUTOB_WIN_SMP'
 assert(param:add_param(KEY, 11,  "AVG_LIM", 20),'could not add AUTOB_AVG_LIM')    -- Pitch limit
 assert(param:add_param(KEY, 12,"PEAK_LIM", 30),'could not add AUTOB_PEAK_LIM')
 assert(param:add_param(KEY, 13, "DBG_EN", 0), 'could not add AUTOB_DBG_EN')  -- 1 = enable dataflash logging
-assert(param:add_param(KEY, 14, "PRED_INT", 500), 'could not add AUTOB_DBG_EN')  -- Rate based VTOL pitch prediction interval
+assert(param:add_param(KEY, 14, "PRED_INT", 500), 'could not add AUTOB_PRED_INT')  -- Rate based VTOL pitch prediction interval
 
 -- 3. BIND PARAMETERS
 local function bind_param(name)
@@ -217,7 +217,7 @@ function update()
     local target_vtol_pitch_deg = desired and (desired.pitch_cd * 0.01) or 0
     local actual_vtol_pitch_deg = actual  and (actual.pitch_cd  * 0.01) or 0
     local vtol_pitch_rate_pid = qp_rate_pid_info(1)
-    local current_instance_vtol_pitch_rate = rad2deg(vtol_pitch_rate_pid.actual or 0)
+    local current_instance_vtol_pitch_rate =  vtol_pitch_rate_pid and rad2deg(vtol_pitch_rate_pid.actual or 0) or 0
     local pitch_prediction_interval = p_prediction_interval:get() or 0
     local predicted_next_instance_vtol_pitch = actual_vtol_pitch_deg + current_instance_vtol_pitch_rate * pitch_prediction_interval/1000
 

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1694,6 +1694,39 @@ function quadplane:abort_landing() end
 function quadplane:tailsitter_in_vtol_transition() end
 
 -- desc
+---@return number -- roll_cd
+---@return number -- pitch_cd
+---@return number -- yaw_cd
+function qp_att_desired() end
+
+-- desc
+---@return number -- roll_cd
+---@return number -- pitch_cd
+---@return number -- yaw_cd
+function qp_att_actual() end
+
+-- desc
+---@return number -- roll_dps
+---@return number -- pitch_dps
+---@return number -- yaw_dps
+function qp_angle_rate() end
+
+
+--desc
+---@param axis integer
+---| '0' # Roll axis
+---| '1' # Pitch axis
+---| '2' # Yaw axis
+---@return number -- P 
+---@return number -- I
+---@return number -- D
+---@return number -- FF
+---@return number -- target rad/s
+---@return number -- actual rad/s
+---@return number -- error rad/s
+function qp_rate_pid_info(axis) end
+
+-- desc
 ---@class LED
 LED = {}
 


### PR DESCRIPTION
- Add rate based vtol pitch prediction and uses the predicted angle to trigger autobailout
https://app.notion.com/p/airbound/Add-pitch-angle-prediction-in-autobailout-script-38121adf4be9802781d9fe294e987660
- Change parameters AUTOB_BTRN_DLY and AUTOB_PRED_INT
https://app.notion.com/p/airbound/Find-AUTOB_BTRN_DLY-and-AUTOB_PRED_INT-based-on-log-analysis-38a21adf4be9800599f8d3c818b59510